### PR TITLE
refactor: ergonomic conversions

### DIFF
--- a/linkup-cli/src/local_server.rs
+++ b/linkup-cli/src/local_server.rs
@@ -19,12 +19,12 @@ async fn linkup_config_handler(
 ) -> impl Responder {
     let sessions = SessionAllocator::new(string_store.into_inner());
 
-    let input_yaml_conf = match String::from_utf8(req_body.to_vec()) {
-        Ok(input_yaml_conf) => input_yaml_conf,
+    let input_json_conf = match String::from_utf8(req_body.to_vec()) {
+        Ok(input_json_conf) => input_json_conf,
         Err(_) => return HttpResponse::BadRequest().body("Invalid request body encoding"),
     };
 
-    match update_session_req_from_json(input_yaml_conf) {
+    match update_session_req_from_json(input_json_conf) {
         Ok((desired_name, server_conf)) => {
             let session_name = sessions
                 .store_session(server_conf, NameKind::Animal, desired_name)

--- a/linkup/src/lib.rs
+++ b/linkup/src/lib.rs
@@ -258,7 +258,8 @@ mod tests {
     async fn test_get_request_session_by_subdomain() {
         let sessions = SessionAllocator::new(Arc::new(MemoryStringStore::new()));
 
-        let config = session_from_yml(String::from(CONF_STR)).unwrap();
+        let config_value: serde_yaml::Value = serde_yaml::from_str(CONF_STR).unwrap();
+        let config: Session = config_value.try_into().unwrap();
 
         let name = sessions
             .store_session(config, NameKind::Animal, "".to_string())
@@ -372,7 +373,8 @@ mod tests {
     async fn test_get_target_url() {
         let sessions = SessionAllocator::new(Arc::new(MemoryStringStore::new()));
 
-        let input_config = session_from_yml(String::from(CONF_STR)).unwrap();
+        let input_config_value: serde_yaml::Value = serde_yaml::from_str(CONF_STR).unwrap();
+        let input_config: Session = input_config_value.try_into().unwrap();
 
         let name = sessions
             .store_session(input_config, NameKind::Animal, "".to_string())


### PR DESCRIPTION
### Description
This PR suggests the change of the methods for conversion to leverage the [From](https://doc.rust-lang.org/std/convert/trait.From.html) \ [TryFrom](https://doc.rust-lang.org/std/convert/trait.TryFrom.html) traits.

### Other changes (I can revert specific ones if don't agree)
- Rename `input_yaml_conf` to `input_json_conf` since it seems like the default now is to use JSON.
- Change the responsibility of who needs to verify the structural validity of the input (JSON/YAML). With the current proposal, the Session is constructed from a format validated value (`serde_json::Value`/`serde_yaml::Value`) and the caller is the one responsible for handling invalid format.