### PR TITLE
refactor: move linkup from YAML to JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,7 +998,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serde_yaml",
  "thiserror",
  "tokio",
  "url",

--- a/linkup/Cargo.toml
+++ b/linkup/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 regex = "1.7.1"
 serde = "1.0.156"
-serde_yaml = "0.9.19"
 thiserror = "1.0.39"
 url = { version = "2.3.1", features = ["serde"] }
 rand = "0.8"


### PR DESCRIPTION
### Description

This PR moves from YAML to JSON.

Note: the tests are currently not passing on `main`, and consequently not passing here. Haven't had time to look into it.