### PR TITLE
style: highlight services status warning

### DIFF
--- a/linkup-cli/src/status.rs
+++ b/linkup-cli/src/status.rs
@@ -130,8 +130,7 @@ pub fn status(json: bool) -> Result<(), CliError> {
         .iter()
         .any(|s| s.component_kind == "linkup" && s.status != ServerStatus::Ok)
     {
-        println!();
-        println!("Some linkup services are not running correctly. Please check the status of the services.");
+        println!("{}", "Some linkup services are not running correctly. Please check the status of the services.".yellow());
         std::process::exit(1);
     }
 


### PR DESCRIPTION
### Description
This PR adds color to the warning that is printed before exiting the program.
The idea behind this is to draw more attention to this message regarding possible issues with services.

#### From:
![Screenshot 2023-05-23 at 07 53 12](https://github.com/mentimeter/linkup/assets/5747313/bf5de565-5500-4c82-945c-090b2aef1a9a)

#### To:
![Screenshot 2023-05-23 at 07 54 21](https://github.com/mentimeter/linkup/assets/5747313/f292f5a3-4278-466a-9ef4-d50752e3891c)
