### PR TITLE
multiple small features

### DIFF
--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -132,6 +132,8 @@ enum Commands {
         // Output status in JSON format
         #[arg(long)]
         json: bool,
+        #[arg(short, long)]
+        all: bool,
     },
 }
 
@@ -146,6 +148,6 @@ fn main() -> Result<(), CliError> {
         Commands::Reset { config } => reset(config.clone()),
         Commands::Local { service_names } => local(service_names.clone()),
         Commands::Remote { service_names } => remote(service_names.clone()),
-        Commands::Status { json } => status(*json),
+        Commands::Status { json, all } => status(*json, *all),
     }
 }

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -9,12 +9,14 @@ mod background_tunnel;
 mod local_config;
 mod local_server;
 mod remote_local;
+mod reset;
 mod signal;
 mod start;
 mod status;
 mod stop;
 
 use remote_local::{local, remote};
+use reset::reset;
 use start::start;
 use status::status;
 use stop::stop;
@@ -93,6 +95,8 @@ pub enum CliError {
     StatusErr(String),
     #[error("your session is in an inconsistent state. Stop your session before trying again.")]
     InconsistentState,
+    #[error("no such service: {0}")]
+    NoSuchService(String),
 }
 
 #[derive(Parser)]
@@ -114,10 +118,15 @@ enum Commands {
     },
     #[clap(about = "Stop a running linkup session")]
     Stop {},
+    #[clap(about = "Reset a linkup session")]
+    Reset {
+        #[arg(short, long)]
+        config: Option<String>,
+    },
     #[clap(about = "Route session traffic to a local service")]
-    Local { service_name: String },
+    Local { service_names: Vec<String> },
     #[clap(about = "Route session traffic to a remote service")]
-    Remote { service_name: String },
+    Remote { service_names: Vec<String> },
     #[clap(about = "View linkup component and service status")]
     Status {
         // Output status in JSON format
@@ -134,8 +143,9 @@ fn main() -> Result<(), CliError> {
     match &cli.command {
         Commands::Start { config } => start(config.clone()),
         Commands::Stop {} => stop(),
-        Commands::Local { service_name } => local(service_name.clone()),
-        Commands::Remote { service_name } => remote(service_name.clone()),
+        Commands::Reset { config } => reset(config.clone()),
+        Commands::Local { service_names } => local(service_names.clone()),
+        Commands::Remote { service_names } => remote(service_names.clone()),
         Commands::Status { json } => status(*json),
     }
 }

--- a/linkup-cli/src/remote_local.rs
+++ b/linkup-cli/src/remote_local.rs
@@ -7,49 +7,58 @@ use crate::{
     CliError, LINKUP_LOCALSERVER_PORT,
 };
 
-pub fn remote(service_name: String) -> Result<(), CliError> {
+pub fn remote(service_names: Vec<String>) -> Result<(), CliError> {
+    if service_names.is_empty() {
+        return Err(CliError::NoSuchService(
+            "No service names provided".to_string(),
+        ));
+    }
     let mut state = get_state()?;
 
-    let service = state
-        .services
-        .iter_mut()
-        .find(|s| s.name == service_name)
-        .ok_or(CliError::BadConfig(format!(
-            "Service {} not found",
-            service_name
-        )))?;
-    service.current = ServiceTarget::Remote;
+    for service_name in service_names.clone() {
+        let service = state
+            .services
+            .iter_mut()
+            .find(|s| s.name == service_name)
+            .ok_or(CliError::NoSuchService(service_name))?;
+        service.current = ServiceTarget::Remote;
+    }
 
     save_state(state.clone())?;
     load_server_states(state)?;
 
     println!(
         "Linkup is routing {} traffic to the remote server",
-        service_name
+        service_names.join(", ")
     );
 
     Ok(())
 }
 
-pub fn local(service_name: String) -> Result<(), CliError> {
+pub fn local(service_names: Vec<String>) -> Result<(), CliError> {
+    if service_names.is_empty() {
+        return Err(CliError::NoSuchService(
+            "No service names provided".to_string(),
+        ));
+    }
+
     let mut state = get_state()?;
 
-    let service = state
-        .services
-        .iter_mut()
-        .find(|s| s.name == service_name)
-        .ok_or(CliError::BadConfig(format!(
-            "Service {} not found",
-            service_name
-        )))?;
-    service.current = ServiceTarget::Local;
+    for service_name in service_names.clone() {
+        let service = state
+            .services
+            .iter_mut()
+            .find(|s| s.name == service_name)
+            .ok_or(CliError::NoSuchService(service_name))?;
+        service.current = ServiceTarget::Local;
+    }
 
     save_state(state.clone())?;
     load_server_states(state)?;
 
     println!(
         "Linkup is routing {} traffic to the local server",
-        service_name
+        service_names.join(", ")
     );
 
     Ok(())

--- a/linkup-cli/src/reset.rs
+++ b/linkup-cli/src/reset.rs
@@ -1,0 +1,6 @@
+use crate::{start, stop, CliError};
+
+pub fn reset(config_arg: Option<String>) -> Result<(), CliError> {
+    stop()?;
+    start(config_arg)
+}

--- a/linkup-cli/src/status.rs
+++ b/linkup-cli/src/status.rs
@@ -29,7 +29,7 @@ struct ServiceStatus {
 }
 
 #[derive(Deserialize, Serialize, PartialEq)]
-enum ServerStatus {
+pub enum ServerStatus {
     Ok,
     Error,
     Timeout,
@@ -242,7 +242,7 @@ fn service_status(tx: std::sync::mpsc::Sender<ServiceStatus>, state: &LocalState
     }
 }
 
-fn server_status(url: String) -> ServerStatus {
+pub fn server_status(url: String) -> ServerStatus {
     let client = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(2))
         .build();

--- a/linkup-cli/src/status.rs
+++ b/linkup-cli/src/status.rs
@@ -55,7 +55,7 @@ impl From<Result<reqwest::blocking::Response, reqwest::Error>> for ServerStatus 
     }
 }
 
-pub fn status(json: bool) -> Result<(), CliError> {
+pub fn status(json: bool, all: bool) -> Result<(), CliError> {
     let state = get_state()?;
 
     let (tx, rx) = std::sync::mpsc::channel();
@@ -71,13 +71,21 @@ pub fn status(json: bool) -> Result<(), CliError> {
             .then(a.name.cmp(&b.name))
     });
 
-    let status = Status {
+    let mut status = Status {
         session: SessionStatus {
             name: state.linkup.session_name.clone(),
             domains: format_state_domains(&state),
         },
         services,
     };
+
+    if !all && !json {
+        status.services = status
+            .services
+            .into_iter()
+            .filter(|s| s.status != ServerStatus::Ok || s.component_kind == "local")
+            .collect();
+    }
 
     if json {
         println!(

--- a/linkup-cli/src/stop.rs
+++ b/linkup-cli/src/stop.rs
@@ -39,7 +39,10 @@ pub fn stop() -> Result<(), CliError> {
     }
 
     match (local_stopped, tunnel_stopped) {
-        (Ok(_), Ok(_)) => Ok(()),
+        (Ok(_), Ok(_)) => {
+            println!("Stopped linkup");
+            Ok(())
+        }
         (Err(e), _) => Err(e),
         (_, Err(e)) => Err(e),
     }

--- a/linkup-cli/src/stop.rs
+++ b/linkup-cli/src/stop.rs
@@ -1,5 +1,5 @@
 use std::fs::{self, File, OpenOptions};
-use std::io::{BufRead, BufReader, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use crate::signal::{send_sigint, PidError};


### PR DESCRIPTION
* support list of services in `local`/`remote`
* filter out OK and non-local services from `status` by default
* warn if local servers are already running locally when starting
* add reset command (stop & start)