### PR TITLE
feat: add local-dns command

### DIFF
--- a/linkup-cli/src/local_config.rs
+++ b/linkup-cli/src/local_config.rs
@@ -48,20 +48,35 @@ impl Display for ServiceTarget {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub struct YamlLocalConfig {
     linkup: LinkupConfig,
     services: Vec<YamlLocalService>,
     domains: Vec<StorableDomain>,
 }
 
-#[derive(Deserialize)]
+impl YamlLocalConfig {
+    pub fn top_level_domains(&self) -> Vec<String> {
+        self.domains
+            .iter()
+            .filter(|&d| {
+                !self
+                    .domains
+                    .iter()
+                    .any(|other| other.domain != d.domain && d.domain.ends_with(&other.domain))
+            })
+            .map(|d| d.domain.clone())
+            .collect::<Vec<String>>()
+    }
+}
+
+#[derive(Deserialize, Clone)]
 struct LinkupConfig {
     remote: Url,
     cache_routes: Option<Vec<String>>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 struct YamlLocalService {
     name: String,
     remote: Url,

--- a/linkup-cli/src/local_dns.rs
+++ b/linkup-cli/src/local_dns.rs
@@ -1,9 +1,12 @@
-use std::{fs, process::{Command, Stdio}};
+use std::{
+    fs,
+    process::{Command, Stdio},
+};
 
 use crate::{
-    CliError,
     linkup_file_path,
-    LINKUP_LOCALDNS_INSTALL, local_config::{config_path, get_config}, Result,
+    local_config::{config_path, get_config},
+    CliError, Result, LINKUP_LOCALDNS_INSTALL,
 };
 
 pub fn install(config_arg: &Option<String>) -> Result<()> {
@@ -163,7 +166,6 @@ fn kill_dns_responder() -> Result<()> {
     Ok(())
 }
 
-
 fn is_sudo() -> bool {
     let sudo_check = Command::new("sudo")
         .arg("-n")
@@ -177,5 +179,5 @@ fn is_sudo() -> bool {
         return exit_status.success();
     }
 
-    return false;
+    false
 }

--- a/linkup-cli/src/local_dns.rs
+++ b/linkup-cli/src/local_dns.rs
@@ -28,7 +28,7 @@ pub fn install(config_arg: &Option<String>) -> Result<()> {
     Ok(())
 }
 
-pub fn uninstall(config: &Option<String>) -> Result<()> {
+pub fn uninstall(_config: &Option<String>) -> Result<()> {
     todo!()
 }
 
@@ -36,7 +36,7 @@ pub fn uninstall(config: &Option<String>) -> Result<()> {
 
 fn ensure_resolver_dir() -> Result<()> {
     Command::new("sudo")
-        .args(&["mkdir", "/etc/resolver"])
+        .args(["mkdir", "/etc/resolver"])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
@@ -50,7 +50,7 @@ fn ensure_resolver_dir() -> Result<()> {
     Ok(())
 }
 
-fn install_resolvers(resolve_domains: &Vec<String>) -> Result<()> {
+fn install_resolvers(resolve_domains: &[String]) -> Result<()> {
     for domain in resolve_domains.iter() {
         let cmd_str = format!(
             "echo \"nameserver 127.0.0.1\nport 8053\" > /etc/resolver/{}",
@@ -77,9 +77,11 @@ fn install_resolvers(resolve_domains: &Vec<String>) -> Result<()> {
     }
 
     let status_flush = Command::new("sudo")
-        .args(&["dscacheutil", "-flushcache"])
+        .args(["dscacheutil", "-flushcache"])
         .status()
-        .map_err(|err| CliError::LocalDNSInstall("Failed to run dscacheutil -flushcache".into()))?;
+        .map_err(|_err| {
+            CliError::LocalDNSInstall("Failed to run dscacheutil -flushcache".into())
+        })?;
 
     if !status_flush.success() {
         return Err(CliError::LocalDNSInstall(
@@ -88,9 +90,9 @@ fn install_resolvers(resolve_domains: &Vec<String>) -> Result<()> {
     }
 
     let status_killall = Command::new("sudo")
-        .args(&["killall", "-HUP", "mDNSResponder"])
+        .args(["killall", "-HUP", "mDNSResponder"])
         .status()
-        .map_err(|err| {
+        .map_err(|_err| {
             CliError::LocalDNSInstall("Failed to run killall -HUP mDNSResponder".into())
         })?;
 

--- a/linkup-cli/src/local_dns.rs
+++ b/linkup-cli/src/local_dns.rs
@@ -10,9 +10,8 @@ use crate::{
 };
 
 pub fn install(config_arg: &Option<String>) -> Result<()> {
-    // TODO(augustoccesar)[2023-09-22]: Does this function really need a copy of the config arg?
-    let config_path = config_path(config_arg.clone())?;
-    let input_config = get_config(config_path.clone())?;
+    let config_path = config_path(config_arg)?;
+    let input_config = get_config(&config_path)?;
 
     println!("Installing local-dns requires sudo.");
     println!("Linkup will put files into /etc/resolver/<domain>.");

--- a/linkup-cli/src/local_dns.rs
+++ b/linkup-cli/src/local_dns.rs
@@ -6,16 +6,20 @@ use std::{
 use crate::{
     linkup_file_path,
     local_config::{config_path, get_config},
-    CliError, Result, LINKUP_LOCALDNS_INSTALL, LINKUP_CF_TLS_API_ENV_VAR,
+    services, CliError, Result, LINKUP_CF_TLS_API_ENV_VAR, LINKUP_LOCALDNS_INSTALL,
 };
 
 pub fn install(config_arg: &Option<String>) -> Result<()> {
     if std::env::var(LINKUP_CF_TLS_API_ENV_VAR).is_err() {
         println!("local-dns uses Cloudflare to enable https through local certificates.");
-        println!("To use it, you need to set the {} environment variable.", LINKUP_CF_TLS_API_ENV_VAR);
-        return Err(CliError::LocalDNSInstall(
-            format!("{} env var is not set", LINKUP_CF_TLS_API_ENV_VAR),
-        ));
+        println!(
+            "To use it, you need to set the {} environment variable.",
+            LINKUP_CF_TLS_API_ENV_VAR
+        );
+        return Err(CliError::LocalDNSInstall(format!(
+            "{} env var is not set",
+            LINKUP_CF_TLS_API_ENV_VAR
+        )));
     }
 
     let config_path = config_path(config_arg)?;
@@ -30,6 +34,7 @@ pub fn install(config_arg: &Option<String>) -> Result<()> {
 
     ensure_resolver_dir()?;
     install_resolvers(&input_config.top_level_domains())?;
+    services::caddy::install_cloudflare_package()?;
 
     if fs::write(linkup_file_path(LINKUP_LOCALDNS_INSTALL), "").is_err() {
         return Err(CliError::LocalDNSInstall(format!(

--- a/linkup-cli/src/local_dns.rs
+++ b/linkup-cli/src/local_dns.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     linkup_file_path,
-    start::{config_path, get_config},
+    local_config::{config_path, get_config},
     CliError, Result, LINKUP_LOCALDNS_INSTALL,
 };
 

--- a/linkup-cli/src/local_dns.rs
+++ b/linkup-cli/src/local_dns.rs
@@ -6,10 +6,18 @@ use std::{
 use crate::{
     linkup_file_path,
     local_config::{config_path, get_config},
-    CliError, Result, LINKUP_LOCALDNS_INSTALL,
+    CliError, Result, LINKUP_LOCALDNS_INSTALL, LINKUP_CF_TLS_API_ENV_VAR,
 };
 
 pub fn install(config_arg: &Option<String>) -> Result<()> {
+    if std::env::var(LINKUP_CF_TLS_API_ENV_VAR).is_err() {
+        println!("local-dns uses Cloudflare to enable https through local certificates.");
+        println!("To use it, you need to set the {} environment variable.", LINKUP_CF_TLS_API_ENV_VAR);
+        return Err(CliError::LocalDNSInstall(
+            format!("{} env var is not set", LINKUP_CF_TLS_API_ENV_VAR),
+        ));
+    }
+
     let config_path = config_path(config_arg)?;
     let input_config = get_config(&config_path)?;
 

--- a/linkup-cli/src/local_dns.rs
+++ b/linkup-cli/src/local_dns.rs
@@ -1,0 +1,105 @@
+use std::{
+    fs,
+    process::{Command, Stdio},
+};
+
+use crate::{
+    linkup_file_path,
+    start::{config_path, get_config},
+    CliError, Result, LINKUP_LOCALDNS_INSTALL,
+};
+
+pub fn install(config_arg: &Option<String>) -> Result<()> {
+    // TODO(augustoccesar)[2023-09-22]: Does this function really need a copy of the config arg?
+    let config_path = config_path(config_arg.clone())?;
+    let input_config = get_config(config_path.clone())?;
+
+    println!("Installing local-dns requires sudo.");
+    println!("Linkup will put files into /etc/resolver/<domain>.");
+    ensure_resolver_dir()?;
+    install_resolvers(&input_config.top_level_domains())?;
+
+    if fs::write(linkup_file_path(LINKUP_LOCALDNS_INSTALL), "").is_err() {
+        return Err(CliError::LocalDNSInstall(format!(
+            "Failed to write install localdns file at {}",
+            linkup_file_path(LINKUP_LOCALDNS_INSTALL).display()
+        )));
+    };
+
+    Ok(())
+}
+
+pub fn uninstall(config: &Option<String>) -> Result<()> {
+    todo!()
+}
+
+// ---
+
+fn ensure_resolver_dir() -> Result<()> {
+    Command::new("sudo")
+        .args(&["mkdir", "/etc/resolver"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|err| {
+            CliError::LocalDNSInstall(format!(
+                "failed to create /etc/resolver folder. Reason: {}",
+                err
+            ))
+        })?;
+
+    Ok(())
+}
+
+fn install_resolvers(resolve_domains: &Vec<String>) -> Result<()> {
+    for domain in resolve_domains.iter() {
+        let cmd_str = format!(
+            "echo \"nameserver 127.0.0.1\nport 8053\" > /etc/resolver/{}",
+            domain
+        );
+        let status = Command::new("sudo")
+            .arg("bash")
+            .arg("-c")
+            .arg(&cmd_str)
+            .status()
+            .map_err(|err| {
+                CliError::LocalDNSInstall(format!(
+                    "Failed to install resolver for domain {} to /etc/resolver/{}. Reason: {}",
+                    domain, domain, err
+                ))
+            })?;
+
+        if !status.success() {
+            return Err(CliError::LocalDNSInstall(format!(
+                "Failed to install resolver for domain {} to /etc/resolver/{}",
+                domain, domain
+            )));
+        }
+    }
+
+    let status_flush = Command::new("sudo")
+        .args(&["dscacheutil", "-flushcache"])
+        .status()
+        .map_err(|err| CliError::LocalDNSInstall("Failed to run dscacheutil -flushcache".into()))?;
+
+    if !status_flush.success() {
+        return Err(CliError::LocalDNSInstall(
+            "Failed to run dscacheutil -flushcache".into(),
+        ));
+    }
+
+    let status_killall = Command::new("sudo")
+        .args(&["killall", "-HUP", "mDNSResponder"])
+        .status()
+        .map_err(|err| {
+            CliError::LocalDNSInstall("Failed to run killall -HUP mDNSResponder".into())
+        })?;
+
+    if !status_killall.success() {
+        return Err(CliError::LocalDNSInstall(
+            "Failed to run killall -HUP mDNSResponder".into(),
+        ));
+    }
+
+    Ok(())
+}

--- a/linkup-cli/src/local_server.rs
+++ b/linkup-cli/src/local_server.rs
@@ -7,6 +7,7 @@ use futures::stream::StreamExt;
 use thiserror::Error;
 
 use linkup::*;
+use url::Url;
 
 use crate::LINKUP_LOCALSERVER_PORT;
 
@@ -201,7 +202,18 @@ async fn linkup_request_handler(
             }
         };
 
-    let extra_headers = get_additional_headers(url, &headers, &session_name, &dest_service_name);
+    let mut extra_headers =
+        get_additional_headers(url, &headers, &session_name, &dest_service_name);
+
+    // TODO: this is ugly
+    extra_headers.insert(
+        "host".to_string(),
+        Url::parse(&destination_url)
+            .unwrap()
+            .host_str()
+            .unwrap()
+            .to_string(),
+    );
 
     // Proxy the request using the destination_url and the merged headers
     let client = reqwest::Client::new();
@@ -238,10 +250,11 @@ fn merge_headers(
     extra_headers: &HashMap<String, String>,
 ) -> reqwest::header::HeaderMap {
     let mut header_map = reqwest::header::HeaderMap::new();
+    // Give the extra headers precedence
     for (key, value) in original_headers.iter().chain(extra_headers.iter()) {
         if let Ok(header_name) = reqwest::header::HeaderName::from_bytes(key.as_bytes()) {
             if let Ok(header_value) = reqwest::header::HeaderValue::from_str(value) {
-                header_map.append(header_name, header_value);
+                header_map.insert(header_name, header_value);
             }
         }
     }

--- a/linkup-cli/src/local_server.rs
+++ b/linkup-cli/src/local_server.rs
@@ -205,7 +205,7 @@ async fn linkup_request_handler(
     let mut extra_headers =
         get_additional_headers(url, &headers, &session_name, &dest_service_name);
 
-    // TODO: this is ugly
+    // TODO(ostenbom): Consider moving host override into additional_headers function
     extra_headers.insert(
         "host".to_string(),
         Url::parse(&destination_url)

--- a/linkup-cli/src/local_server.rs
+++ b/linkup-cli/src/local_server.rs
@@ -60,7 +60,7 @@ async fn linkup_ws_request_handler(
 ) -> impl Responder {
     let sessions = SessionAllocator::new(string_store.into_inner());
 
-    let url = format!("http://localhost:9066{}", req.uri());
+    let url = format!("http://localhost:{}{}", LINKUP_LOCALSERVER_PORT, req.uri());
     let headers = req
         .headers()
         .iter()
@@ -168,7 +168,7 @@ async fn linkup_request_handler(
 ) -> impl Responder {
     let sessions = SessionAllocator::new(string_store.into_inner());
 
-    let url = format!("http://localhost:9066{}", req.uri());
+    let url = format!("http://localhost:{}{}", LINKUP_LOCALSERVER_PORT, req.uri());
     let headers = req
         .headers()
         .iter()

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -189,7 +189,7 @@ fn main() -> Result<()> {
         Commands::Status { json, all } => status(*json, *all),
         Commands::LocalDNS { config, subcommand } => match subcommand {
             LocalDNSSubcommand::Install => local_dns::install(config),
-            LocalDNSSubcommand::Uninstall => local_dns::install(config),
+            LocalDNSSubcommand::Uninstall => local_dns::uninstall(config),
         },
         Commands::Completion { shell } => completion(shell),
     }

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -13,6 +13,7 @@ mod local_dns;
 mod local_server;
 mod remote_local;
 mod reset;
+mod services;
 mod signal;
 mod start;
 mod status;
@@ -33,12 +34,7 @@ const LINKUP_LOCALSERVER_PID_FILE: &str = "localserver-pid";
 const LINKUP_CLOUDFLARED_PID: &str = "cloudflared-pid";
 const LINKUP_ENV_SEPARATOR: &str = "##### Linkup environment - DO NOT EDIT #####";
 const LINKUP_LOCALDNS_INSTALL: &str = "localdns-install";
-const LINKUP_CADDYFILE: &str = "Caddyfile";
-const LINKUP_CADDY_PID_FILE: &str = "caddy-pid";
 const LINKUP_CF_TLS_API_ENV_VAR: &str = "LINKUP_CF_API_TOKEN";
-const LINKUP_DNSMASQ_CONF_FILE: &str = "dnsmasq-conf";
-const LINKUP_DNSMASQ_LOG_FILE: &str = "dnsmasq-log";
-const LINKUP_DNSMASQ_PID_FILE: &str = "dnsmasq-pid";
 
 pub fn linkup_dir_path() -> PathBuf {
     let storage_dir = match env::var("HOME") {

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -9,6 +9,7 @@ mod background_local_server;
 mod background_tunnel;
 mod completion;
 mod local_config;
+mod local_dns;
 mod local_server;
 mod remote_local;
 mod reset;
@@ -31,8 +32,14 @@ const LINKUP_STATE_FILE: &str = "state";
 const LINKUP_LOCALSERVER_PID_FILE: &str = "localserver-pid";
 const LINKUP_CLOUDFLARED_PID: &str = "cloudflared-pid";
 const LINKUP_ENV_SEPARATOR: &str = "##### Linkup environment - DO NOT EDIT #####";
+const LINKUP_LOCALDNS_INSTALL: &str = "localdns-install";
+const LINKUP_CADDYFILE: &str = "Caddyfile";
+const LINKUP_CADDY_PID_FILE: &str = "caddy-pid";
+const LINKUP_DNSMASQ_CONF_FILE: &str = "dnsmasq-conf";
+const LINKUP_DNSMASQ_LOG_FILE: &str = "dnsmasq-log";
+const LINKUP_DNSMASQ_PID_FILE: &str = "dnsmasq-pid";
 
-pub fn linkup_file_path(file: &str) -> PathBuf {
+pub fn linkup_dir_path() -> PathBuf {
     let storage_dir = match env::var("HOME") {
         Ok(val) => val,
         Err(_e) => "/var/tmp".to_string(),
@@ -41,19 +48,17 @@ pub fn linkup_file_path(file: &str) -> PathBuf {
     let mut path = PathBuf::new();
     path.push(storage_dir);
     path.push(LINKUP_DIR);
+    path
+}
+
+pub fn linkup_file_path(file: &str) -> PathBuf {
+    let mut path = linkup_dir_path();
     path.push(file);
     path
 }
 
-fn ensure_linkup_dir() -> Result<(), CliError> {
-    let storage_dir = match env::var("HOME") {
-        Ok(val) => val,
-        Err(_e) => "/var/tmp".to_string(),
-    };
-
-    let mut path = PathBuf::new();
-    path.push(storage_dir);
-    path.push(LINKUP_DIR);
+fn ensure_linkup_dir() -> Result<()> {
+    let path = linkup_dir_path();
 
     match fs::create_dir(&path) {
         Ok(_) => Ok(()),
@@ -67,6 +72,8 @@ fn ensure_linkup_dir() -> Result<(), CliError> {
         },
     }
 }
+
+pub type Result<T> = std::result::Result<T, CliError>;
 
 #[derive(Error, Debug)]
 pub enum CliError {
@@ -90,6 +97,8 @@ pub enum CliError {
     StartLocalTunnel(String),
     #[error("linkup component did not start in time: {0}")]
     StartLinkupTimeout(String),
+    #[error("could not start Caddy: {0}")]
+    StartCaddy(String),
     #[error("could not load config to {0}: {1}")]
     LoadConfig(String, String),
     #[error("could not stop: {0}")]
@@ -100,6 +109,8 @@ pub enum CliError {
     InconsistentState,
     #[error("no such service: {0}")]
     NoSuchService(String),
+    #[error("failed to install local dns: {0}")]
+    LocalDNSInstall(String),
 }
 
 #[derive(Parser)]
@@ -110,6 +121,11 @@ pub enum CliError {
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+}
+#[derive(Subcommand)]
+enum LocalDNSSubcommand {
+    Install,
+    Uninstall,
 }
 
 #[derive(Subcommand)]
@@ -140,6 +156,18 @@ enum Commands {
         #[arg(short, long)]
         all: bool,
     },
+    LocalDNS {
+        #[arg(
+            short,
+            long,
+            value_name = "CONFIG",
+            help = "Path to config file, overriding environment variable."
+        )]
+        config: Option<String>,
+
+        #[clap(subcommand)]
+        subcommand: LocalDNSSubcommand,
+    },
     #[clap(about = "Generate completions for your shell")]
     Completion {
         #[arg(long, value_enum)]
@@ -147,7 +175,7 @@ enum Commands {
     },
 }
 
-fn main() -> Result<(), CliError> {
+fn main() -> Result<()> {
     let cli = Cli::parse();
 
     ensure_linkup_dir()?;
@@ -159,6 +187,10 @@ fn main() -> Result<(), CliError> {
         Commands::Local { service_names } => local(service_names.clone()),
         Commands::Remote { service_names } => remote(service_names.clone()),
         Commands::Status { json, all } => status(*json, *all),
+        Commands::LocalDNS { config, subcommand } => match subcommand {
+            LocalDNSSubcommand::Install => local_dns::install(config),
+            LocalDNSSubcommand::Uninstall => local_dns::install(config),
+        },
         Commands::Completion { shell } => completion(shell),
     }
 }

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -110,6 +110,8 @@ pub enum CliError {
     LocalDNSInstall(String),
     #[error("failed to uninstall local dns: {0}")]
     LocalDNSUninstall(String),
+    #[error("failed to write file: {0}")]
+    WriteFile(String),
 }
 
 #[derive(Parser)]

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -111,6 +111,8 @@ pub enum CliError {
     NoSuchService(String),
     #[error("failed to install local dns: {0}")]
     LocalDNSInstall(String),
+    #[error("failed to uninstall local dns: {0}")]
+    LocalDNSUninstall(String),
 }
 
 #[derive(Parser)]

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -144,7 +144,15 @@ enum Commands {
     #[clap(about = "Stop a running linkup session")]
     Stop {},
     #[clap(about = "Reset a linkup session")]
-    Reset {},
+    Reset {
+        #[arg(
+            short,
+            long,
+            value_name = "CONFIG",
+            help = "Path to config file, overriding environment variable."
+        )]
+        config: Option<String>,
+    },
     #[clap(about = "Route session traffic to a local service")]
     Local { service_names: Vec<String> },
     #[clap(about = "Route session traffic to a remote service")]
@@ -184,7 +192,7 @@ fn main() -> Result<()> {
     match &cli.command {
         Commands::Start { config } => start(config.clone()),
         Commands::Stop {} => stop(),
-        Commands::Reset {} => reset(),
+        Commands::Reset { config } => reset(config),
         Commands::Local { service_names } => local(service_names.clone()),
         Commands::Remote { service_names } => remote(service_names.clone()),
         Commands::Status { json, all } => status(*json, *all),

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -35,6 +35,7 @@ const LINKUP_ENV_SEPARATOR: &str = "##### Linkup environment - DO NOT EDIT #####
 const LINKUP_LOCALDNS_INSTALL: &str = "localdns-install";
 const LINKUP_CADDYFILE: &str = "Caddyfile";
 const LINKUP_CADDY_PID_FILE: &str = "caddy-pid";
+const LINKUP_CF_TLS_API_ENV_VAR: &str = "LINKUP_CF_API_TOKEN";
 const LINKUP_DNSMASQ_CONF_FILE: &str = "dnsmasq-conf";
 const LINKUP_DNSMASQ_LOG_FILE: &str = "dnsmasq-log";
 const LINKUP_DNSMASQ_PID_FILE: &str = "dnsmasq-pid";

--- a/linkup-cli/src/reset.rs
+++ b/linkup-cli/src/reset.rs
@@ -1,11 +1,26 @@
 use crate::{
-    background_booting::boot_background_services, start::get_state, stop::shutdown, CliError,
+    background_booting::boot_background_services,
+    linkup_file_path,
+    local_config::{config_path, get_config},
+    start::{boot_local_dns, get_state},
+    stop::shutdown,
+    CliError, LINKUP_LOCALDNS_INSTALL,
 };
 
-pub fn reset() -> Result<(), CliError> {
+// TODO(ostenbom)[2023-09-26]: Config arg shouldn't be needed here, we could use config state for this
+pub fn reset(config_arg: &Option<String>) -> Result<(), CliError> {
     // Ensure there is some kind of state from before, otherwise reset doesn't make sense
     get_state()?;
 
     shutdown()?;
-    boot_background_services()
+    boot_background_services()?;
+
+    if linkup_file_path(LINKUP_LOCALDNS_INSTALL).exists() {
+        let config_path = config_path(config_arg)?;
+        let input_config = get_config(&config_path)?;
+
+        boot_local_dns(&input_config)?;
+    }
+
+    Ok(())
 }

--- a/linkup-cli/src/services/caddy.rs
+++ b/linkup-cli/src/services/caddy.rs
@@ -82,7 +82,7 @@ fn write_caddyfile(domains: &[String]) -> Result<()> {
             }}
         }}
         ",
-        linkup_file_path(LOG_FILE).display(), // TODO(augustoccesar)[2023-09-25]: Is display enough for this?
+        linkup_file_path(LOG_FILE).display(),
         domains.join(", "),
         LINKUP_LOCALSERVER_PORT,
         LINKUP_CF_TLS_API_ENV_VAR,

--- a/linkup-cli/src/services/caddy.rs
+++ b/linkup-cli/src/services/caddy.rs
@@ -1,0 +1,88 @@
+use std::{
+    fs,
+    process::{Command, Stdio},
+};
+
+use crate::{
+    linkup_dir_path, linkup_file_path, local_config::YamlLocalConfig, CliError, Result,
+    LINKUP_CF_TLS_API_ENV_VAR,
+};
+
+const CADDYFILE: &str = "Caddyfile";
+const PID_FILE: &str = "caddy-pid";
+const LOG_FILE: &str = "caddy-log";
+
+pub fn start(local_config: &YamlLocalConfig) -> Result<()> {
+    if std::env::var(LINKUP_CF_TLS_API_ENV_VAR).is_err() {
+        return Err(CliError::StartCaddy(format!(
+            "{} env var is not set",
+            LINKUP_CF_TLS_API_ENV_VAR
+        )));
+    }
+
+    let domains: Vec<String> = local_config
+        .top_level_domains()
+        .iter()
+        .map(|domain| format!("*.{}", domain))
+        .collect();
+
+    write_caddyfile(&domains)?;
+
+    Command::new("caddy")
+        .current_dir(linkup_dir_path())
+        .arg("start")
+        .arg("--pidfile")
+        .arg(linkup_file_path(PID_FILE))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|err| CliError::StartCaddy(err.to_string()))?;
+
+    Ok(())
+}
+
+pub fn stop() -> Result<()> {
+    Command::new("caddy")
+        .current_dir(linkup_dir_path())
+        .arg("stop")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|err| CliError::StopErr(err.to_string()))?;
+
+    Ok(())
+}
+
+fn write_caddyfile(domains: &[String]) -> Result<()> {
+    let caddy_template = format!(
+        "
+        {{
+            http_port 80
+            https_port 443
+            log {{
+                output file {}
+            }}
+        }}
+
+        {} {{
+            reverse_proxy localhost:9066
+            tls {{
+                dns cloudflare {{env.{}}}
+            }}
+        }}
+        ",
+        linkup_file_path(LOG_FILE).display(), // TODO(augustoccesar)[2023-09-25]: Is display enough for this?
+        domains.join(", "),
+        LINKUP_CF_TLS_API_ENV_VAR,
+    );
+
+    let caddyfile_path = linkup_file_path(CADDYFILE);
+    if fs::write(&caddyfile_path, caddy_template).is_err() {
+        return Err(CliError::SaveState(format!(
+            "Failed to write Caddyfile at {}",
+            caddyfile_path.display(),
+        )));
+    }
+
+    Ok(())
+}

--- a/linkup-cli/src/services/caddy.rs
+++ b/linkup-cli/src/services/caddy.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     linkup_dir_path, linkup_file_path, local_config::YamlLocalConfig, CliError, Result,
-    LINKUP_CF_TLS_API_ENV_VAR,
+    LINKUP_CF_TLS_API_ENV_VAR, LINKUP_LOCALSERVER_PORT,
 };
 
 const CADDYFILE: &str = "Caddyfile";
@@ -76,7 +76,7 @@ fn write_caddyfile(domains: &[String]) -> Result<()> {
         }}
 
         {} {{
-            reverse_proxy localhost:9066
+            reverse_proxy localhost:{}
             tls {{
                 dns cloudflare {{env.{}}}
             }}
@@ -84,6 +84,7 @@ fn write_caddyfile(domains: &[String]) -> Result<()> {
         ",
         linkup_file_path(LOG_FILE).display(), // TODO(augustoccesar)[2023-09-25]: Is display enough for this?
         domains.join(", "),
+        LINKUP_LOCALSERVER_PORT,
         LINKUP_CF_TLS_API_ENV_VAR,
     );
 

--- a/linkup-cli/src/services/caddy.rs
+++ b/linkup-cli/src/services/caddy.rs
@@ -53,6 +53,17 @@ pub fn stop() -> Result<()> {
     Ok(())
 }
 
+pub fn install_cloudflare_package() -> Result<()> {
+    Command::new("caddy")
+        .args(["add-package", "github.com/caddy-dns/cloudflare"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|err| CliError::StartCaddy(err.to_string()))?;
+
+    Ok(())
+}
+
 fn write_caddyfile(domains: &[String]) -> Result<()> {
     let caddy_template = format!(
         "

--- a/linkup-cli/src/services/caddy.rs
+++ b/linkup-cli/src/services/caddy.rs
@@ -90,7 +90,7 @@ fn write_caddyfile(domains: &[String]) -> Result<()> {
 
     let caddyfile_path = linkup_file_path(CADDYFILE);
     if fs::write(&caddyfile_path, caddy_template).is_err() {
-        return Err(CliError::SaveState(format!(
+        return Err(CliError::WriteFile(format!(
             "Failed to write Caddyfile at {}",
             caddyfile_path.display(),
         )));

--- a/linkup-cli/src/services/dnsmasq.rs
+++ b/linkup-cli/src/services/dnsmasq.rs
@@ -17,8 +17,7 @@ pub fn start() -> Result<()> {
     let pidfile_path = linkup_file_path(PID_FILE);
 
     if fs::write(&logfile_path, "").is_err() {
-        return Err(CliError::SaveState(format!(
-            // TODO(augustoccesar)[2023-09-25]: Is SaveState the error that we want here?
+        return Err(CliError::WriteFile(format!(
             "Failed to write dnsmasq log file at {}",
             logfile_path.display()
         )));
@@ -59,8 +58,7 @@ fn write_conf_file(conf_file_path: &Path, logfile_path: &Path, pidfile_path: &Pa
     );
 
     if fs::write(conf_file_path, dnsmasq_template).is_err() {
-        return Err(CliError::SaveState(format!(
-            // TODO(augustoccesar)[2023-09-25]: Is SaveState the error that we want here?
+        return Err(CliError::WriteFile(format!(
             "Failed to write dnsmasq config at {}",
             conf_file_path.display()
         )));

--- a/linkup-cli/src/services/dnsmasq.rs
+++ b/linkup-cli/src/services/dnsmasq.rs
@@ -42,7 +42,7 @@ pub fn start() -> Result<()> {
 
 // TODO(augustoccesar)[2023-09-26]: Do we really want to swallow these errors?
 pub fn stop() {
-    let _ = stop_pid_file(&linkup_file_path(PID_FILE), Signal::SIGKILL);
+    let _ = stop_pid_file(&linkup_file_path(PID_FILE), Signal::SIGTERM);
 }
 
 fn write_conf_file(conf_file_path: &Path, logfile_path: &Path, pidfile_path: &Path) -> Result<()> {

--- a/linkup-cli/src/services/dnsmasq.rs
+++ b/linkup-cli/src/services/dnsmasq.rs
@@ -1,0 +1,70 @@
+use std::{
+    fs,
+    path::Path,
+    process::{Command, Stdio},
+};
+
+use crate::{linkup_dir_path, linkup_file_path, stop::stop_pid_file, CliError, Result};
+
+const PORT: u16 = 8053;
+const CONF_FILE: &str = "dnsmasq-conf";
+const LOG_FILE: &str = "dnsmasq-log";
+const PID_FILE: &str = "dnsmasq-pid";
+
+pub fn start() -> Result<()> {
+    let conf_file_path = linkup_file_path(CONF_FILE);
+    let logfile_path = linkup_file_path(LOG_FILE);
+    let pidfile_path = linkup_file_path(PID_FILE);
+
+    if fs::write(&logfile_path, "").is_err() {
+        return Err(CliError::SaveState(format!(
+            // TODO(augustoccesar)[2023-09-25]: Is SaveState the error that we want here?
+            "Failed to write dnsmasq log file at {}",
+            logfile_path.display()
+        )));
+    }
+
+    write_conf_file(&conf_file_path, &logfile_path, &pidfile_path)?;
+
+    Command::new("dnsmasq")
+        .current_dir(linkup_dir_path())
+        .arg("--log-queries") // TODO(augustoccesar)[2023-09-22]: Do we really need this?
+        .arg("-C")
+        .arg(conf_file_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|err| CliError::StartCaddy(err.to_string()))?;
+
+    Ok(())
+}
+
+pub fn stop() -> Result<()> {
+    stop_pid_file(PID_FILE)?;
+
+    Ok(())
+}
+
+fn write_conf_file(conf_file_path: &Path, logfile_path: &Path, pidfile_path: &Path) -> Result<()> {
+    let dnsmasq_template = format!(
+        "
+            address=/#/127.0.0.1
+            port={}
+            log-facility={}
+            pid-file={}
+        ",
+        PORT,
+        logfile_path.display(),
+        pidfile_path.display(),
+    );
+
+    if fs::write(conf_file_path, dnsmasq_template).is_err() {
+        return Err(CliError::SaveState(format!(
+            // TODO(augustoccesar)[2023-09-25]: Is SaveState the error that we want here?
+            "Failed to write dnsmasq config at {}",
+            conf_file_path.display()
+        )));
+    }
+
+    Ok(())
+}

--- a/linkup-cli/src/services/dnsmasq.rs
+++ b/linkup-cli/src/services/dnsmasq.rs
@@ -27,7 +27,7 @@ pub fn start() -> Result<()> {
 
     Command::new("dnsmasq")
         .current_dir(linkup_dir_path())
-        .arg("--log-queries") // TODO(augustoccesar)[2023-09-22]: Do we really need this?
+        .arg("--log-queries")
         .arg("-C")
         .arg(conf_file_path)
         .stdout(Stdio::null())

--- a/linkup-cli/src/services/dnsmasq.rs
+++ b/linkup-cli/src/services/dnsmasq.rs
@@ -4,7 +4,7 @@ use std::{
     process::{Command, Stdio},
 };
 
-use crate::{linkup_dir_path, linkup_file_path, stop::stop_pid_file, CliError, Result};
+use crate::{linkup_dir_path, linkup_file_path, stop::kill_pid_file, CliError, Result};
 
 const PORT: u16 = 8053;
 const CONF_FILE: &str = "dnsmasq-conf";
@@ -39,7 +39,10 @@ pub fn start() -> Result<()> {
 }
 
 pub fn stop() -> Result<()> {
-    stop_pid_file(PID_FILE)?;
+    let dnsmasq_stopped = kill_pid_file(PID_FILE);
+    if dnsmasq_stopped.is_ok() {
+        let _ = std::fs::remove_file(linkup_file_path(PID_FILE));
+    }
 
     Ok(())
 }

--- a/linkup-cli/src/services/dnsmasq.rs
+++ b/linkup-cli/src/services/dnsmasq.rs
@@ -4,7 +4,9 @@ use std::{
     process::{Command, Stdio},
 };
 
-use crate::{linkup_dir_path, linkup_file_path, stop::kill_pid_file, CliError, Result};
+use nix::sys::signal::Signal;
+
+use crate::{linkup_dir_path, linkup_file_path, stop::stop_pid_file, CliError, Result};
 
 const PORT: u16 = 8053;
 const CONF_FILE: &str = "dnsmasq-conf";
@@ -38,13 +40,9 @@ pub fn start() -> Result<()> {
     Ok(())
 }
 
-pub fn stop() -> Result<()> {
-    let dnsmasq_stopped = kill_pid_file(PID_FILE);
-    if dnsmasq_stopped.is_ok() {
-        let _ = std::fs::remove_file(linkup_file_path(PID_FILE));
-    }
-
-    Ok(())
+// TODO(augustoccesar)[2023-09-26]: Do we really want to swallow these errors?
+pub fn stop() {
+    let _ = stop_pid_file(&linkup_file_path(PID_FILE), Signal::SIGKILL);
 }
 
 fn write_conf_file(conf_file_path: &Path, logfile_path: &Path, pidfile_path: &Path) -> Result<()> {

--- a/linkup-cli/src/services/mod.rs
+++ b/linkup-cli/src/services/mod.rs
@@ -1,0 +1,2 @@
+pub mod caddy;
+pub mod dnsmasq;

--- a/linkup-cli/src/signal.rs
+++ b/linkup-cli/src/signal.rs
@@ -1,5 +1,7 @@
 use nix::sys::signal::{kill, Signal};
 use nix::unistd::Pid;
+use std::fs::{self, File};
+use std::path::Path;
 use std::str::FromStr;
 use thiserror::Error;
 
@@ -15,30 +17,27 @@ pub enum PidError {
     NoSuchProcess(String),
 }
 
-pub fn send_sigint(pid_str: &str) -> Result<(), PidError> {
+pub fn send_signal(pid_str: &str, signal: Signal) -> Result<(), PidError> {
     // Parse the PID string to a i32
     let pid_num = i32::from_str(pid_str).map_err(|e| PidError::BadPidFile(e.to_string()))?;
 
     // Create a Pid from the i32
     let pid = Pid::from_raw(pid_num);
 
-    match kill(pid, Some(Signal::SIGINT)) {
+    match kill(pid, Some(signal)) {
         Ok(_) => Ok(()),
         Err(nix::Error::ESRCH) => Err(PidError::NoSuchProcess(pid_str.to_string())),
         Err(e) => Err(PidError::SignalErr(e.to_string())),
     }
 }
 
-pub fn send_sigkill(pid_str: &str) -> Result<(), PidError> {
-    // Parse the PID string to a i32
-    let pid_num = i32::from_str(pid_str).map_err(|e| PidError::BadPidFile(e.to_string()))?;
+pub fn get_pid(file_path: &Path) -> Result<String, PidError> {
+    if let Err(e) = File::open(file_path) {
+        return Err(PidError::NoPidFile(e.to_string()));
+    }
 
-    // Create a Pid from the i32
-    let pid = Pid::from_raw(pid_num);
-
-    match kill(pid, Some(Signal::SIGKILL)) {
-        Ok(_) => Ok(()),
-        Err(nix::Error::ESRCH) => Err(PidError::NoSuchProcess(pid_str.to_string())),
-        Err(e) => Err(PidError::SignalErr(e.to_string())),
+    match fs::read_to_string(file_path) {
+        Ok(content) => Ok(content.trim().to_string()),
+        Err(e) => Err(PidError::BadPidFile(e.to_string())),
     }
 }

--- a/linkup-cli/src/signal.rs
+++ b/linkup-cli/src/signal.rs
@@ -28,3 +28,17 @@ pub fn send_sigint(pid_str: &str) -> Result<(), PidError> {
         Err(e) => Err(PidError::SignalErr(e.to_string())),
     }
 }
+
+pub fn send_sigkill(pid_str: &str) -> Result<(), PidError> {
+    // Parse the PID string to a i32
+    let pid_num = i32::from_str(pid_str).map_err(|e| PidError::BadPidFile(e.to_string()))?;
+
+    // Create a Pid from the i32
+    let pid = Pid::from_raw(pid_num);
+
+    match kill(pid, Some(Signal::SIGKILL)) {
+        Ok(_) => Ok(()),
+        Err(nix::Error::ESRCH) => Err(PidError::NoSuchProcess(pid_str.to_string())),
+        Err(e) => Err(PidError::SignalErr(e.to_string())),
+    }
+}

--- a/linkup-cli/src/start.rs
+++ b/linkup-cli/src/start.rs
@@ -20,8 +20,8 @@ use crate::{
 
 pub fn start(config_arg: Option<String>) -> Result<(), CliError> {
     let previous_state = get_state();
-    let config_path = config_path(config_arg)?;
-    let input_config = get_config(config_path.clone())?;
+    let config_path = config_path(&config_arg)?;
+    let input_config = get_config(&config_path)?;
 
     let mut state = config_to_state(input_config.clone(), config_path);
 
@@ -56,8 +56,7 @@ pub fn start(config_arg: Option<String>) -> Result<(), CliError> {
 }
 
 // TODO(augustoccesar)[2023-09-22]: Move this into a shared file. Maybe local_config?
-// TODO(augustoccesar)[2023-09-22]: Does this function really ownership of the param?
-pub fn config_path(config_arg: Option<String>) -> Result<String, CliError> {
+pub fn config_path(config_arg: &Option<String>) -> Result<String, CliError> {
     match config_arg {
         Some(path) => {
             let absolute_path = fs::canonicalize(path)
@@ -80,9 +79,8 @@ pub fn config_path(config_arg: Option<String>) -> Result<String, CliError> {
 }
 
 // TODO(augustoccesar)[2023-09-22]: Move this into a shared file. Maybe local_config?
-// TODO(augustoccesar)[2023-09-22]: Does this function really ownership of the param?
-pub fn get_config(config_path: String) -> Result<YamlLocalConfig, CliError> {
-    let content = match fs::read_to_string(&config_path) {
+pub fn get_config(config_path: &str) -> Result<YamlLocalConfig, CliError> {
+    let content = match fs::read_to_string(config_path) {
         Ok(content) => content,
         Err(_) => {
             return Err(CliError::BadConfig(format!(

--- a/linkup-cli/src/start.rs
+++ b/linkup-cli/src/start.rs
@@ -185,7 +185,7 @@ fn check_local_not_started() -> Result<(), CliError> {
     Ok(())
 }
 
-fn boot_local_dns(local_config: &YamlLocalConfig) -> Result<(), CliError> {
+pub fn boot_local_dns(local_config: &YamlLocalConfig) -> Result<(), CliError> {
     services::caddy::start(local_config)?;
     services::dnsmasq::start()?;
 

--- a/linkup-cli/src/start.rs
+++ b/linkup-cli/src/start.rs
@@ -16,7 +16,7 @@ use crate::{services, LINKUP_LOCALDNS_INSTALL};
 
 pub fn start(config_arg: &Option<String>) -> Result<(), CliError> {
     let previous_state = get_state();
-    let config_path = config_path(&config_arg)?;
+    let config_path = config_path(config_arg)?;
     let input_config = get_config(&config_path)?;
 
     let mut state = config_to_state(input_config.clone(), config_path);

--- a/linkup-cli/src/start.rs
+++ b/linkup-cli/src/start.rs
@@ -1,7 +1,6 @@
 use std::io::Write;
 use std::process::{Command, Stdio};
 use std::{
-    env,
     fs::{self, File, OpenOptions},
     path::{Path, PathBuf},
 };
@@ -12,7 +11,7 @@ use crate::{
     linkup_file_path,
     local_config::{config_to_state, LocalState, YamlLocalConfig},
     status::{server_status, ServerStatus},
-    CliError, LINKUP_CONFIG_ENV, LINKUP_ENV_SEPARATOR, LINKUP_STATE_FILE,
+    CliError, LINKUP_ENV_SEPARATOR, LINKUP_STATE_FILE,
 };
 use crate::{
     linkup_dir_path, LINKUP_CADDYFILE, LINKUP_CADDY_PID_FILE, LINKUP_DNSMASQ_CONF_FILE,

--- a/linkup-cli/src/status.rs
+++ b/linkup-cli/src/status.rs
@@ -80,11 +80,9 @@ pub fn status(json: bool, all: bool) -> Result<(), CliError> {
     };
 
     if !all && !json {
-        status.services = status
+        status
             .services
-            .into_iter()
-            .filter(|s| s.status != ServerStatus::Ok || s.component_kind == "local")
-            .collect();
+            .retain(|s| s.status != ServerStatus::Ok || s.component_kind == "local");
     }
 
     if json {

--- a/linkup-cli/src/stop.rs
+++ b/linkup-cli/src/stop.rs
@@ -34,8 +34,6 @@ pub fn shutdown() -> Result<(), CliError> {
         Signal::SIGINT,
     );
 
-    // TODO(augustoccesar)[2023-09-26]: This pidfile seems to have the liknkup process pid, not cloudflared pid. So this is deleting the file
-    //   but not actually stopping cloudflared
     let tunnel_stopped = stop_pid_file(&linkup_file_path(LINKUP_CLOUDFLARED_PID), Signal::SIGINT);
 
     if linkup_file_path(LINKUP_LOCALDNS_INSTALL).exists() {

--- a/linkup-cli/src/stop.rs
+++ b/linkup-cli/src/stop.rs
@@ -1,13 +1,12 @@
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 
 use crate::signal::{send_sigint, PidError};
 use crate::start::get_state;
 use crate::{
-    linkup_dir_path, linkup_file_path, CliError, LINKUP_CLOUDFLARED_PID, LINKUP_DNSMASQ_PID_FILE,
-    LINKUP_ENV_SEPARATOR, LINKUP_LOCALDNS_INSTALL, LINKUP_LOCALSERVER_PID_FILE,
+    linkup_file_path, services, CliError, LINKUP_CLOUDFLARED_PID, LINKUP_ENV_SEPARATOR,
+    LINKUP_LOCALDNS_INSTALL, LINKUP_LOCALSERVER_PID_FILE,
 };
 
 pub fn stop() -> Result<(), CliError> {
@@ -152,13 +151,6 @@ fn remove_service_env(directory: String, config_path: String) -> Result<(), CliE
 }
 
 fn stop_localdns_services() {
-    let _ = Command::new("caddy")
-        .current_dir(linkup_dir_path())
-        .arg("stop")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map_err(|err| CliError::StopErr(err.to_string()));
-
-    let _ = stop_pid_file(LINKUP_DNSMASQ_PID_FILE);
+    let _ = services::caddy::stop();
+    let _ = services::dnsmasq::stop();
 }

--- a/linkup/src/lib.rs
+++ b/linkup/src/lib.rs
@@ -118,7 +118,9 @@ pub fn get_target_service(
 ) -> Option<(String, String)> {
     let mut target = Url::parse(&url).unwrap();
     // Ensure always the default port, even when the local server is hit first
-    target.set_port(None);
+    target
+        .set_port(None)
+        .expect("setting port to None is always valid");
     let path = target.path();
 
     // If there was a destination created in a previous linkup, we don't want to
@@ -133,14 +135,13 @@ pub fn get_target_service(
     let url_target = config.domains.get(&get_target_domain(&url, session_name));
 
     // Forwarded hosts persist over the tunnel
-    let forwarded_host_target = config.domains.get(
-        &get_target_domain(
-            headers.get("x-forwarded-host").unwrap_or(
-                headers
-                    .get("X-Forwarded-Host")
-                    .unwrap_or(&"does-not-exist".to_string()),
-            ),
-            session_name,
+    let forwarded_host_target = config.domains.get(&get_target_domain(
+        headers.get("x-forwarded-host").unwrap_or(
+            headers
+                .get("X-Forwarded-Host")
+                .unwrap_or(&"does-not-exist".to_string()),
+        ),
+        session_name,
     ));
 
     // This is more for e2e tests to work

--- a/linkup/src/session_allocator.rs
+++ b/linkup/src/session_allocator.rs
@@ -24,6 +24,13 @@ impl SessionAllocator {
             return Ok((url_name, config));
         }
 
+        if let Some(forwarded_host) = headers.get("x-forwarded-host") {
+            let forwarded_host_name = first_subdomain(forwarded_host);
+            if let Some(config) = self.get_session_config(forwarded_host_name.to_string()).await? {
+                return Ok((forwarded_host_name, config));
+            }
+        }
+
         if let Some(referer) = headers.get("referer") {
             let referer_name = first_subdomain(referer);
             if let Some(config) = self.get_session_config(referer_name.to_string()).await? {

--- a/worker/src/http_util.rs
+++ b/worker/src/http_util.rs
@@ -42,7 +42,7 @@ pub fn merge_headers(
     {
         if let Ok(header_name) = reqwest::header::HeaderName::from_bytes(key.as_bytes()) {
             if let Ok(header_value) = reqwest::header::HeaderValue::from_str(&value) {
-                header_map.append(header_name, header_value);
+                header_map.insert(header_name, header_value);
             }
         }
     }


### PR DESCRIPTION
### Description
Makes it possible to install local DNS routing for linkup.

Uses of a combination of [caddy](https://caddyserver.com/) and [dnsmasq](https://thekelleys.org.uk/dnsmasq/doc.html) to achieve local TLS/SSL and DNS for this to work in a frictionless way.