### PR TITLE
refactor: handle new lines to avoid interfering with existing variables

### DIFF
--- a/linkup-cli/src/start.rs
+++ b/linkup-cli/src/start.rs
@@ -129,12 +129,16 @@ fn set_service_env(directory: String, config_path: String) -> Result<(), CliErro
             }
         }
 
-        let dev_env_content = fs::read_to_string(&dev_env_path).map_err(|e| {
+        let mut dev_env_content = fs::read_to_string(&dev_env_path).map_err(|e| {
             CliError::SetServiceEnv(
                 directory.clone(),
                 format!("could not read dev env file: {}", e),
             )
         })?;
+
+        if dev_env_content.ends_with('\n') {
+            dev_env_content.pop();
+        }
 
         let mut env_file = OpenOptions::new()
             .create(true)
@@ -147,7 +151,7 @@ fn set_service_env(directory: String, config_path: String) -> Result<(), CliErro
                 )
             })?;
 
-        writeln!(env_file, "{}", LINKUP_ENV_SEPARATOR).map_err(|e| {
+        writeln!(env_file, "\n{}", LINKUP_ENV_SEPARATOR).map_err(|e| {
             CliError::SetServiceEnv(
                 directory.clone(),
                 format!("could not write to env file: {}", e),

--- a/linkup-cli/src/stop.rs
+++ b/linkup-cli/src/stop.rs
@@ -115,10 +115,23 @@ fn remove_service_env(directory: String, config_path: String) -> Result<(), CliE
         let start_idx = file_content.find(LINKUP_ENV_SEPARATOR);
         let end_idx = file_content.rfind(LINKUP_ENV_SEPARATOR);
 
-        if let (Some(start), Some(end)) = (start_idx, end_idx) {
+        if let (Some(mut start), Some(mut end)) = (start_idx, end_idx) {
             if start < end {
-                file_content.drain(start..=end + LINKUP_ENV_SEPARATOR.len() - 1);
+                let new_line_above_start =
+                    start > 1 && file_content.chars().nth(start - 1) == Some('\n');
+                let new_line_bellow_end = file_content.chars().nth(end + 1) == Some('\n');
+
+                if new_line_above_start {
+                    start = start - 1;
+                }
+
+                if new_line_bellow_end {
+                    end = end + 1;
+                }
+
+                file_content.drain(start..=end + LINKUP_ENV_SEPARATOR.len());
             }
+
             if file_content.ends_with('\n') {
                 file_content.pop();
             }


### PR DESCRIPTION
With this new change, when writing the new variables, Linkup will start by adding a new line to avoid writing the header on the same line as the latest variable. On cleanup, it will also remove the wrapping new lines around the Linkup block (if any).

So, for example:
An existing config:
```
```

After start
```
##### Linkup environment - DO NOT EDIT #####
...
...
...
##### Linkup environment - DO NOT EDIT #####
```

After stop
```
```

Or an existing config:
```
a
b
c
```

After start
```
a
b
c
##### Linkup environment - DO NOT EDIT #####
...
...
...
##### Linkup environment - DO NOT EDIT #####

```

After stop
```
a
b
c
```

Or even if modified between start and stop, where existing is:
```
a
b
c
```

After start
```
a
b
c
##### Linkup environment - DO NOT EDIT #####
...
...
...
##### Linkup environment - DO NOT EDIT #####

```

Then modified to
```
a
b
c
##### Linkup environment - DO NOT EDIT #####
...
...
...
##### Linkup environment - DO NOT EDIT #####

d
e
```

After stop
```
a
b
c
d
e
```