### PR TITLE
feat: add Clippy to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 on:
   pull_request:
 
-name: Continuous integration
+name: CI
 
 jobs:
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,45 +5,28 @@ name: Continuous integration
 
 jobs:
   check:
-    name: Check
+    name: Check and Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo check --all
+      - run: rustup component add clippy
+      - run: cargo clippy
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --all-features
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
   check:
     name: Check and Clippy
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable

--- a/e2e/src/main.rs
+++ b/e2e/src/main.rs
@@ -197,29 +197,6 @@ fn check_process_dead(pid_str: &str) -> Result<()> {
     }
 }
 
-fn print_linkup_files() -> Result<()> {
-    // Get the home directory
-    let home = env::var("HOME").unwrap();
-    let linkup_dir = format!("{}/.linkup", home);
-
-    // Read the directory entries
-    for entry in fs::read_dir(linkup_dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_file() {
-            // Print the file name
-            let file_name = path.file_name().unwrap().to_string_lossy();
-            println!("File name: {}", file_name);
-
-            // Read and print the file content
-            let content = fs::read_to_string(&path)?;
-            println!("File content: {}", content);
-        }
-    }
-
-    Ok(())
-}
-
 fn main() {
     if let Err(e) = run_with_cleanup() {
         println!("An error occurred: {}", e);

--- a/linkup-cli/src/background_tunnel.rs
+++ b/linkup-cli/src/background_tunnel.rs
@@ -119,7 +119,7 @@ fn try_start_tunnel() -> Result<Url, CliError> {
                             if let Some(url) = &url {
                                 tx.send(Ok(url.clone())).expect("Failed to send tunnel URL");
                                 return;
-                            }       
+                            }
                         }
                     }
                 }

--- a/linkup-cli/src/background_tunnel.rs
+++ b/linkup-cli/src/background_tunnel.rs
@@ -115,10 +115,11 @@ fn try_start_tunnel() -> Result<Url, CliError> {
                             found_started = true;
                         }
 
-                        if url.is_some() && found_started {
-                            let u = url.unwrap();
-                            tx.send(Ok(u)).expect("Failed to send tunnel URL");
-                            return;
+                        if found_started {
+                            if let Some(url) = &url {
+                                tx.send(Ok(url.clone())).expect("Failed to send tunnel URL");
+                                return;
+                            }       
                         }
                     }
                 }

--- a/linkup-cli/src/remote_local.rs
+++ b/linkup-cli/src/remote_local.rs
@@ -15,7 +15,7 @@ pub fn remote(service_names: &[String]) -> Result<(), CliError> {
     }
     let mut state = get_state()?;
 
-    for service_name in service_names.clone() {
+    for service_name in service_names {
         let service = state
             .services
             .iter_mut()
@@ -44,7 +44,7 @@ pub fn local(service_names: &[String]) -> Result<(), CliError> {
 
     let mut state = get_state()?;
 
-    for service_name in service_names.clone() {
+    for service_name in service_names {
         let service = state
             .services
             .iter_mut()

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -1,3 +1,8 @@
+// TODO(augustoccesar)[2023-10-16]: We need to revisit the session allocator and how we are using Arc.
+//   It seems that `CfWorkerStringStore` is not really Send or Sync, which is making so that clippy warn about this.
+//   For more info check: https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
+#![allow(clippy::arc_with_non_send_sync)]
+
 use regex::Regex;
 use std::{collections::HashMap, sync::Arc};
 use ws::linkup_ws_handler;

--- a/worker/src/ws.rs
+++ b/worker/src/ws.rs
@@ -113,7 +113,7 @@ fn forward_ws_event(
                     Ok(_) => Ok(()),
                     Err(e) => {
                         let err_msg = format!("Error sending {} with string: {:?}", description, e);
-                        close_with_internal_error(err_msg.clone(), &from, &to);
+                        close_with_internal_error(err_msg.clone(), from, to);
                         Err(Error::RustError(err_msg))
                     }
                 }
@@ -122,13 +122,13 @@ fn forward_ws_event(
                     Ok(_) => Ok(()),
                     Err(e) => {
                         let err_msg = format!("Error sending {} with bytes: {:?}", description, e);
-                        close_with_internal_error(err_msg.clone(), &from, &to);
+                        close_with_internal_error(err_msg.clone(), from, to);
                         Err(Error::RustError(err_msg))
                     }
                 }
             } else {
                 let err_msg = format!("Error message {} no text or bytes", description);
-                close_with_internal_error(err_msg.clone(), &from, &to);
+                close_with_internal_error(err_msg.clone(), from, to);
                 Err(Error::RustError(err_msg))
             }
         }
@@ -139,7 +139,7 @@ fn forward_ws_event(
         }
         Err(e) => {
             let err_msg = format!("Other {} error: {:?}", description, e);
-            close_with_internal_error(err_msg.clone(), &from, &to);
+            close_with_internal_error(err_msg.clone(), from, to);
             Err(Error::RustError(err_msg))
         }
     }


### PR DESCRIPTION
### Description
This PR adds Clippy to the CI.

### Changes
- Replace unmaintained actions-rs actions.
- Add step on the check to also run Clippy.
- Fix issues risen by Clippy.
- Shorten the name of the workflow from "Continuous integration" to simply "CI".

### Follow-up
There seems to be an issue with using Arc for non Sync/Send type when handling `CfWorkerStringStore`. Clippy is bringing that up, that is why I had to explicitly allow it, but we should revisit and try to fix it.
For more information check: https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync