### PR TITLE
refactor: rework headers ergonomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,16 +1031,21 @@ checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 name = "linkup"
 version = "0.1.0"
 dependencies = [
+ "actix-http",
+ "actix-web",
  "async-trait",
  "getrandom",
  "hex",
  "rand",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "unicase",
  "url",
+ "worker",
 ]
 
 [[package]]
@@ -2073,6 +2078,15 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -21,17 +21,17 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2079246596c18b4a33e274ae10c0e50613f4d32a4198e09c7b93771013fed74"
+checksum = "a92ef85799cba03f76e4f7c10f533e66d87c9a7e7055f3391f09000ad8351bc9"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
- "ahash 0.8.3",
+ "ahash",
  "base64",
- "bitflags",
+ "bitflags 2.4.1",
  "brotli",
  "bytes",
  "bytestring",
@@ -104,7 +104,7 @@ dependencies = [
  "futures-util",
  "mio",
  "num_cpus",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tracing",
 ]
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.3.1"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3cb42f9566ab176e1ef0b8b3a896529062b4efc6be0123046095914c4c1c96"
+checksum = "0e4a5b5e29603ca8c94a77c65cf874718ceb60292c5a5c3e5f4ace041af462b9"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -145,7 +145,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web-codegen",
- "ahash 0.7.6",
+ "ahash",
  "bytes",
  "bytestring",
  "cfg-if",
@@ -154,7 +154,6 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http",
  "itoa",
  "language-tags",
  "log",
@@ -166,7 +165,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2",
+ "socket2 0.5.4",
  "time",
  "url",
 ]
@@ -188,17 +187,6 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
 
 [[package]]
 name = "ahash"
@@ -281,6 +269,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "block-buffer"
@@ -387,7 +381,7 @@ version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
  "is-terminal",
@@ -778,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
 dependencies = [
  "bytes",
  "fnv",
@@ -894,7 +888,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -1023,9 +1017,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "linkup"
@@ -1210,7 +1204,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset",
@@ -1249,7 +1243,7 @@ version = "0.10.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd2523381e46256e40930512c7fd25562b9eae4812cb52078f155e87217c9d1e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1498,7 +1492,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1507,7 +1501,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1600,7 +1594,7 @@ version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno 0.2.8",
  "io-lifetimes",
  "libc",
@@ -1614,7 +1608,7 @@ version = "0.37.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno 0.3.1",
  "io-lifetimes",
  "libc",
@@ -1690,7 +1684,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1832,6 +1826,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,7 +1881,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -1990,7 +1994,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.4.9",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,6 @@ checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 name = "linkup"
 version = "0.1.0"
 dependencies = [
- "actix-http",
  "actix-web",
  "async-trait",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,4 @@
 [workspace]
 resolver = "2"
 
-members = [
-  "linkup-cli",
-  "linkup",
-  "e2e",
-  "worker",
-]
+members = ["linkup-cli", "linkup", "e2e", "worker"]

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -16,7 +16,7 @@ ctrlc = { version = "3.0", features = ["termination"] }
 daemonize = "0.5.0"
 env_logger = "0.10.0"
 futures = "0.3.28"
-linkup = { path = "../linkup" }
+linkup = { path = "../linkup", features = ["actix", "reqwest"]}
 log = "0.4.17"
 nix = "0.26.2"
 rand = "0.8.5"

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -16,12 +16,15 @@ ctrlc = { version = "3.0", features = ["termination"] }
 daemonize = "0.5.0"
 env_logger = "0.10.0"
 futures = "0.3.28"
-linkup = { path = "../linkup", features = ["actix", "reqwest"]}
+linkup = { path = "../linkup", features = ["actix", "reqwest"] }
 log = "0.4.17"
 nix = "0.26.2"
 rand = "0.8.5"
 regex = "1.7.1"
-reqwest = { version = "0.11.14", default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.11.14", default-features = false, features = [
+    "blocking",
+    "rustls-tls",
+] }
 serde = "1.0.156"
 serde_json = "1.0.96"
 serde_yaml = "0.9.19"

--- a/linkup-cli/src/local_server.rs
+++ b/linkup-cli/src/local_server.rs
@@ -94,7 +94,7 @@ async fn linkup_ws_request_handler(
     headers.extend(&extra_headers);
     let response_result = client
         .request(req.method().clone(), &target_service.url)
-        .headers(headers.as_ref().into())
+        .headers(headers.into())
         .send()
         .await;
 
@@ -196,7 +196,7 @@ async fn linkup_request_handler(
     headers.extend(&extra_headers);
     let response_result = client
         .request(req.method().clone(), &target_service.url)
-        .headers(headers.as_ref().into())
+        .headers(headers.into())
         .body(req_body)
         .send()
         .await;

--- a/linkup-cli/src/local_server.rs
+++ b/linkup-cli/src/local_server.rs
@@ -1,12 +1,13 @@
-use std::{collections::HashMap, io};
+use std::io;
 
 use actix_web::{
-    guard, http::header, middleware, rt, web, App, HttpRequest, HttpResponse, HttpServer, Responder,
+    guard, http::header::ContentType, middleware, rt, web, App, HttpRequest, HttpResponse,
+    HttpServer, Responder,
 };
 use futures::stream::StreamExt;
 use thiserror::Error;
 
-use linkup::*;
+use linkup::{HeaderMap as LinkupHeaderMap, *};
 use url::Url;
 
 use crate::LINKUP_LOCALSERVER_PORT;
@@ -27,7 +28,7 @@ async fn linkup_config_handler(
         Ok(input_json_conf) => input_json_conf,
         Err(_) => {
             return HttpResponse::BadRequest()
-                .append_header(header::ContentType::plaintext())
+                .append_header(ContentType::plaintext())
                 .body("Invalid request body encoding - local server")
         }
     };
@@ -40,12 +41,12 @@ async fn linkup_config_handler(
             match session_name {
                 Ok(session_name) => HttpResponse::Ok().body(session_name),
                 Err(e) => HttpResponse::InternalServerError()
-                    .append_header(header::ContentType::plaintext())
+                    .append_header(ContentType::plaintext())
                     .body(format!("Failed to store server config: {}", e)),
             }
         }
         Err(e) => HttpResponse::BadRequest()
-            .append_header(header::ContentType::plaintext())
+            .append_header(ContentType::plaintext())
             .body(format!(
                 "Failed to parse server config: {} - local server",
                 e
@@ -61,15 +62,9 @@ async fn linkup_ws_request_handler(
     let sessions = SessionAllocator::new(string_store.into_inner());
 
     let url = format!("http://localhost:{}{}", LINKUP_LOCALSERVER_PORT, req.uri());
-    let headers = req
-        .headers()
-        .iter()
-        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
-        .collect::<HashMap<String, String>>();
+    let mut headers = LinkupHeaderMap::from_actix_request(&req);
 
-    let session_result = sessions
-        .get_request_session(url.clone(), headers.clone())
-        .await;
+    let session_result = sessions.get_request_session(&url, &headers).await;
 
     if session_result.is_err() {
         println!("Failed to get session: {:?}", session_result);
@@ -79,28 +74,29 @@ async fn linkup_ws_request_handler(
         Ok(result) => result,
         Err(_) => {
             return HttpResponse::UnprocessableEntity()
-                .append_header(header::ContentType::plaintext())
+                .append_header(ContentType::plaintext())
                 .body("Unprocessable Content - local server")
         }
     };
 
     let (dest_service_name, destination_url) =
-        match get_target_service(url.clone(), headers.clone(), &config, &session_name) {
+        match get_target_service(&url, &headers, &config, &session_name) {
             Some(result) => result,
             None => {
                 return HttpResponse::NotFound()
-                    .append_header(header::ContentType::plaintext())
+                    .append_header(ContentType::plaintext())
                     .body("Not target url for request - local server")
             }
         };
 
-    let extra_headers = get_additional_headers(url, &headers, &session_name, &dest_service_name);
+    let extra_headers = get_additional_headers(&url, &headers, &session_name, &dest_service_name);
 
     // Proxy the request using the destination_url and the merged headers
     let client = reqwest::Client::new();
+    headers.extend(&extra_headers);
     let response_result = client
         .request(req.method().clone(), &destination_url)
-        .headers(merge_headers(&headers, &extra_headers))
+        .headers(headers.as_ref().into())
         .send()
         .await;
 
@@ -108,7 +104,7 @@ async fn linkup_ws_request_handler(
         match response_result {
             Ok(response) => response,
             Err(_) => return HttpResponse::BadGateway()
-                .append_header(header::ContentType::plaintext())
+                .append_header(ContentType::plaintext())
                 .body(
                     "Bad Gateway from local server, could you have forgotten to start the server?",
                 ),
@@ -118,7 +114,7 @@ async fn linkup_ws_request_handler(
     let status = response.status().as_u16();
     if status != 101 {
         return HttpResponse::BadGateway()
-            .append_header(header::ContentType::plaintext())
+            .append_header(ContentType::plaintext())
             .body("The underlying server did not accept the websocket connection.");
     }
 
@@ -128,8 +124,8 @@ async fn linkup_ws_request_handler(
     for (header, value) in response.headers() {
         client_response.insert_header((header.to_owned(), value.to_owned()));
     }
-    for (header, value) in additional_response_headers() {
-        client_response.insert_header((header.to_owned(), value.to_owned()));
+    for (header, value) in &additional_response_headers() {
+        client_response.insert_header((header.to_string(), value.to_string()));
     }
 
     let upgrade_result = response.upgrade().await;
@@ -137,7 +133,7 @@ async fn linkup_ws_request_handler(
         Ok(response) => response,
         Err(_) => {
             return HttpResponse::BadGateway()
-                .append_header(header::ContentType::plaintext())
+                .append_header(ContentType::plaintext())
                 .body("could not upgrade to websocket connection.")
         }
     };
@@ -169,15 +165,9 @@ async fn linkup_request_handler(
     let sessions = SessionAllocator::new(string_store.into_inner());
 
     let url = format!("http://localhost:{}{}", LINKUP_LOCALSERVER_PORT, req.uri());
-    let headers = req
-        .headers()
-        .iter()
-        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
-        .collect::<HashMap<String, String>>();
+    let mut headers = LinkupHeaderMap::from_actix_request(&req);
 
-    let session_result = sessions
-        .get_request_session(url.clone(), headers.clone())
-        .await;
+    let session_result = sessions.get_request_session(&url, &headers).await;
 
     if session_result.is_err() {
         println!("Failed to get session: {:?}", session_result);
@@ -187,27 +177,27 @@ async fn linkup_request_handler(
         Ok(result) => result,
         Err(_) => {
             return HttpResponse::UnprocessableEntity()
-                .append_header(header::ContentType::plaintext())
+                .append_header(ContentType::plaintext())
                 .body("Unprocessable Content - local server")
         }
     };
 
     let (dest_service_name, destination_url) =
-        match get_target_service(url.clone(), headers.clone(), &config, &session_name) {
+        match get_target_service(&url, &headers, &config, &session_name) {
             Some(result) => result,
             None => {
                 return HttpResponse::NotFound()
-                    .append_header(header::ContentType::plaintext())
+                    .append_header(ContentType::plaintext())
                     .body("Not target url for request - local server")
             }
         };
 
     let mut extra_headers =
-        get_additional_headers(url, &headers, &session_name, &dest_service_name);
+        get_additional_headers(&url, &headers, &session_name, &dest_service_name);
 
     // TODO(ostenbom): Consider moving host override into additional_headers function
     extra_headers.insert(
-        "host".to_string(),
+        "host",
         Url::parse(&destination_url)
             .unwrap()
             .host_str()
@@ -217,9 +207,10 @@ async fn linkup_request_handler(
 
     // Proxy the request using the destination_url and the merged headers
     let client = reqwest::Client::new();
+    headers.extend(&extra_headers);
     let response_result = client
         .request(req.method().clone(), &destination_url)
-        .headers(merge_headers(&headers, &extra_headers))
+        .headers(headers.as_ref().into())
         .body(req_body)
         .send()
         .await;
@@ -228,42 +219,24 @@ async fn linkup_request_handler(
         match response_result {
             Ok(response) => response,
             Err(_) => return HttpResponse::BadGateway()
-                .append_header(header::ContentType::plaintext())
+                .append_header(ContentType::plaintext())
                 .body(
                     "Bad Gateway from local server, could you have forgotten to start the server?",
                 ),
         };
 
-    let extra_resp_headers = additional_response_headers();
-
-    convert_reqwest_response(response, extra_resp_headers)
+    convert_reqwest_response(response, &additional_response_headers())
         .await
         .unwrap_or_else(|_| {
             HttpResponse::InternalServerError()
-                .append_header(header::ContentType::plaintext())
+                .append_header(ContentType::plaintext())
                 .body("Could not convert response from reqwest - local server")
         })
 }
 
-fn merge_headers(
-    original_headers: &HashMap<String, String>,
-    extra_headers: &HashMap<String, String>,
-) -> reqwest::header::HeaderMap {
-    let mut header_map = reqwest::header::HeaderMap::new();
-    // Give the extra headers precedence
-    for (key, value) in original_headers.iter().chain(extra_headers.iter()) {
-        if let Ok(header_name) = reqwest::header::HeaderName::from_bytes(key.as_bytes()) {
-            if let Ok(header_value) = reqwest::header::HeaderValue::from_str(value) {
-                header_map.insert(header_name, header_value);
-            }
-        }
-    }
-    header_map
-}
-
 async fn convert_reqwest_response(
     response: reqwest::Response,
-    extra_headers: HashMap<String, String>,
+    extra_headers: &LinkupHeaderMap,
 ) -> Result<HttpResponse, ProxyError> {
     let status_code = response.status();
     let headers = response.headers().clone();
@@ -277,8 +250,8 @@ async fn convert_reqwest_response(
         response_builder.append_header((key, value));
     }
 
-    for (key, value) in extra_headers.iter() {
-        response_builder.insert_header((key.to_owned(), value.to_owned()));
+    for (key, value) in extra_headers.into_iter() {
+        response_builder.insert_header((key.to_string(), value.to_string()));
     }
 
     Ok(response_builder.body(body))

--- a/linkup/Cargo.toml
+++ b/linkup/Cargo.toml
@@ -4,15 +4,27 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-regex = "1.7.1"
-serde = "1.0.156"
-thiserror = "1.0.39"
-url = { version = "2.3.1", features = ["serde"] }
-rand = "0.8"
+async-trait = "0.1.68"
 getrandom = { version = "0.2.8", features = ["js"] }
 hex = "0.4"
-async-trait = "0.1.68"
+rand = "0.8"
+regex = "1.7.1"
+serde = "1.0.156"
 serde_json = "1.0.96"
+thiserror = "1.0.39"
+unicase = "2.7"
+url = { version = "2.3.1", features = ["serde"] }
+
+# features dependencies
+reqwest = { version = "0.11.14", default-features = false, optional = true }
+actix-http = {version = "*", optional = true}
+actix-web = {version = "*", optional = true}
+worker = { version = "0.0.18", optional = true}
 
 [dev-dependencies]
 tokio = { version = "1.28.0", features = ["test-util", "macros"] }
+
+[features]
+reqwest = ["dep:reqwest"]
+actix = ["dep:actix-http", "dep:actix-web"]
+worker = ["dep:worker"]

--- a/linkup/Cargo.toml
+++ b/linkup/Cargo.toml
@@ -17,9 +17,9 @@ url = { version = "2.3.1", features = ["serde"] }
 
 # features dependencies
 reqwest = { version = "0.11.14", default-features = false, optional = true }
-actix-http = {version = "*", optional = true}
-actix-web = {version = "*", optional = true}
-worker = { version = "0.0.18", optional = true}
+actix-http = { version = "3.4", default-features = false, optional = true }
+actix-web = { version = "4.4", default-features = false, optional = true }
+worker = { version = "0.0.18", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.28.0", features = ["test-util", "macros"] }

--- a/linkup/Cargo.toml
+++ b/linkup/Cargo.toml
@@ -17,8 +17,7 @@ url = { version = "2.3.1", features = ["serde"] }
 
 # features dependencies
 reqwest = { version = "0.11.14", default-features = false, optional = true }
-actix-http = { version = "3.4", default-features = false, optional = true }
-actix-web = { version = "4.4", default-features = false, optional = true }
+actix-web = { version = "4.3.1", default-features = false, optional = true }
 worker = { version = "0.0.18", default-features = false, optional = true }
 
 [dev-dependencies]
@@ -26,5 +25,5 @@ tokio = { version = "1.28.0", features = ["test-util", "macros"] }
 
 [features]
 reqwest = ["dep:reqwest"]
-actix = ["dep:actix-http", "dep:actix-web"]
+actix = ["dep:actix-web"]
 worker = ["dep:worker"]

--- a/linkup/src/headers.rs
+++ b/linkup/src/headers.rs
@@ -30,24 +30,24 @@ impl HeaderMap {
         Self(HashMap::new())
     }
 
-    pub fn contains_key(&self, key: &str) -> bool {
+    pub fn contains_key(&self, key: impl ToString) -> bool {
         self.0.contains_key(&UniCase::new(key.to_string()))
     }
 
-    pub fn get(&self, key: &str) -> Option<&str> {
+    pub fn get(&self, key: impl ToString) -> Option<&str> {
         self.0
             .get(&UniCase::new(key.to_string()))
             .map(String::as_ref)
     }
 
-    pub fn get_or_default<'a>(&'a self, key: &'a str, default: &'a str) -> &'a str {
+    pub fn get_or_default<'a>(&'a self, key: impl ToString, default: &'a str) -> &'a str {
         match self.get(key) {
             Some(value) => value,
             None => default,
         }
     }
 
-    pub fn insert(&mut self, key: &str, value: impl ToString) -> Option<String> {
+    pub fn insert(&mut self, key: impl ToString, value: impl ToString) -> Option<String> {
         self.0
             .insert(UniCase::new(key.to_string()), value.to_string())
     }

--- a/linkup/src/headers.rs
+++ b/linkup/src/headers.rs
@@ -135,3 +135,17 @@ impl<'a>
         headers
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::HeaderMap;
+
+    #[test]
+    fn get_case_insensitive() {
+        let mut header_map = HeaderMap::new();
+        header_map.insert("key", "value");
+
+        assert_eq!(header_map.get("key"), Some("value"));
+        assert_eq!(header_map.get("KEY"), Some("value"));
+    }
+}

--- a/linkup/src/headers.rs
+++ b/linkup/src/headers.rs
@@ -59,8 +59,8 @@ impl HeaderMap {
 }
 
 #[cfg(feature = "reqwest")]
-impl From<&HeaderMap> for reqwest::header::HeaderMap {
-    fn from(value: &HeaderMap) -> Self {
+impl From<HeaderMap> for reqwest::header::HeaderMap {
+    fn from(value: HeaderMap) -> Self {
         let mut header_map = reqwest::header::HeaderMap::new();
 
         for (key, value) in value.into_iter() {

--- a/linkup/src/headers.rs
+++ b/linkup/src/headers.rs
@@ -1,0 +1,122 @@
+use std::collections::HashMap;
+
+use unicase::UniCase;
+
+pub struct HeaderMap(HashMap<UniCase<String>, String>);
+
+impl IntoIterator for &HeaderMap {
+    type Item = (UniCase<String>, String);
+    type IntoIter = std::collections::hash_map::IntoIter<UniCase<String>, String>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.clone().into_iter()
+    }
+}
+
+impl Default for HeaderMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AsRef<HeaderMap> for HeaderMap {
+    fn as_ref(&self) -> &HeaderMap {
+        self
+    }
+}
+
+impl HeaderMap {
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.0.contains_key(&UniCase::new(key.to_string()))
+    }
+
+    pub fn get(&self, key: &str) -> Option<&String> {
+        self.0.get(&UniCase::new(key.to_string()))
+    }
+
+    pub fn insert(&mut self, key: &str, value: impl ToString) -> Option<String> {
+        self.0
+            .insert(UniCase::new(key.to_string()), value.to_string())
+    }
+
+    pub fn extend(&mut self, iter: &HeaderMap) {
+        self.0.extend(iter)
+    }
+
+    #[cfg(feature = "actix")]
+    pub fn from_actix_request(req: &actix_web::HttpRequest) -> Self {
+        req.headers().into()
+    }
+
+    #[cfg(feature = "worker")]
+    pub fn from_worker_request(req: &worker::Request) -> Self {
+        req.headers().into()
+    }
+}
+
+#[cfg(feature = "reqwest")]
+impl From<&HeaderMap> for reqwest::header::HeaderMap {
+    fn from(value: &HeaderMap) -> Self {
+        let mut header_map = reqwest::header::HeaderMap::new();
+
+        for (key, value) in value.into_iter() {
+            if let Ok(header_name) = reqwest::header::HeaderName::from_bytes(key.as_bytes()) {
+                if let Ok(header_value) = reqwest::header::HeaderValue::from_str(&value) {
+                    header_map.insert(header_name, header_value);
+                }
+            }
+        }
+
+        header_map
+    }
+}
+
+#[cfg(feature = "worker")]
+impl From<&worker::Headers> for HeaderMap {
+    fn from(value: &worker::Headers) -> Self {
+        value
+            .into_iter()
+            .collect::<HeaderMap>()
+    }
+}
+
+#[cfg(feature = "worker")]
+impl FromIterator<(String, String)> for HeaderMap {
+    fn from_iter<T: IntoIterator<Item = (String, String)>>(
+        iter: T,
+    ) -> Self {
+        let mut headers = HeaderMap::new();
+        for (k, v) in iter {
+            headers.insert(k.as_str(), v);
+        }
+
+        headers
+    }
+}
+
+#[cfg(feature = "actix")]
+impl From<&actix_http::header::HeaderMap> for HeaderMap {
+    fn from(value: &actix_http::header::HeaderMap) -> Self {
+        value
+            .into_iter()
+            .collect::<HeaderMap>()
+    }
+}
+
+#[cfg(feature = "actix")]
+impl <'a> FromIterator<(&'a actix_http::header::HeaderName, &'a actix_http::header::HeaderValue)> for HeaderMap {
+    fn from_iter<T: IntoIterator<Item = (&'a actix_http::header::HeaderName, &'a actix_http::header::HeaderValue)>>(
+        iter: T,
+    ) -> Self {
+        let mut headers = HeaderMap::new();
+        for (k, v) in iter {
+            headers.insert(k.as_str(), v.to_str().unwrap_or(""));
+        }
+
+        headers
+    }
+}

--- a/linkup/src/headers.rs
+++ b/linkup/src/headers.rs
@@ -38,6 +38,13 @@ impl HeaderMap {
         self.0.get(&UniCase::new(key.to_string()))
     }
 
+    pub fn get_or_default<'a>(&'a self, key: &'a str, default: &'a str) -> &'a str {
+        match self.get(key) {
+            Some(value) => value,
+            None => default,
+        }
+    }
+
     pub fn insert(&mut self, key: &str, value: impl ToString) -> Option<String> {
         self.0
             .insert(UniCase::new(key.to_string()), value.to_string())

--- a/linkup/src/headers.rs
+++ b/linkup/src/headers.rs
@@ -34,8 +34,10 @@ impl HeaderMap {
         self.0.contains_key(&UniCase::new(key.to_string()))
     }
 
-    pub fn get(&self, key: &str) -> Option<&String> {
-        self.0.get(&UniCase::new(key.to_string()))
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.0
+            .get(&UniCase::new(key.to_string()))
+            .map(String::as_ref)
     }
 
     pub fn get_or_default<'a>(&'a self, key: &'a str, default: &'a str) -> &'a str {

--- a/linkup/src/headers.rs
+++ b/linkup/src/headers.rs
@@ -41,12 +41,6 @@ impl Default for HeaderMap {
     }
 }
 
-impl AsRef<HeaderMap> for HeaderMap {
-    fn as_ref(&self) -> &HeaderMap {
-        self
-    }
-}
-
 impl HeaderMap {
     pub fn new() -> Self {
         Self(HashMap::new())

--- a/linkup/src/headers.rs
+++ b/linkup/src/headers.rs
@@ -78,17 +78,13 @@ impl From<&HeaderMap> for reqwest::header::HeaderMap {
 #[cfg(feature = "worker")]
 impl From<&worker::Headers> for HeaderMap {
     fn from(value: &worker::Headers) -> Self {
-        value
-            .into_iter()
-            .collect::<HeaderMap>()
+        value.into_iter().collect::<HeaderMap>()
     }
 }
 
 #[cfg(feature = "worker")]
 impl FromIterator<(String, String)> for HeaderMap {
-    fn from_iter<T: IntoIterator<Item = (String, String)>>(
-        iter: T,
-    ) -> Self {
+    fn from_iter<T: IntoIterator<Item = (String, String)>>(iter: T) -> Self {
         let mut headers = HeaderMap::new();
         for (k, v) in iter {
             headers.insert(k.as_str(), v);
@@ -101,15 +97,25 @@ impl FromIterator<(String, String)> for HeaderMap {
 #[cfg(feature = "actix")]
 impl From<&actix_http::header::HeaderMap> for HeaderMap {
     fn from(value: &actix_http::header::HeaderMap) -> Self {
-        value
-            .into_iter()
-            .collect::<HeaderMap>()
+        value.into_iter().collect::<HeaderMap>()
     }
 }
 
 #[cfg(feature = "actix")]
-impl <'a> FromIterator<(&'a actix_http::header::HeaderName, &'a actix_http::header::HeaderValue)> for HeaderMap {
-    fn from_iter<T: IntoIterator<Item = (&'a actix_http::header::HeaderName, &'a actix_http::header::HeaderValue)>>(
+impl<'a>
+    FromIterator<(
+        &'a actix_http::header::HeaderName,
+        &'a actix_http::header::HeaderValue,
+    )> for HeaderMap
+{
+    fn from_iter<
+        T: IntoIterator<
+            Item = (
+                &'a actix_http::header::HeaderName,
+                &'a actix_http::header::HeaderValue,
+            ),
+        >,
+    >(
         iter: T,
     ) -> Self {
         let mut headers = HeaderMap::new();

--- a/linkup/src/headers.rs
+++ b/linkup/src/headers.rs
@@ -11,6 +11,7 @@ pub enum HeaderName {
     LinkupDestination,
     Referer,
     Origin,
+    Host,
 }
 
 impl From<HeaderName> for UniCase<String> {
@@ -22,6 +23,7 @@ impl From<HeaderName> for UniCase<String> {
             HeaderName::LinkupDestination => "linkup-destination".into(),
             HeaderName::Referer => "referer".into(),
             HeaderName::Origin => "origin".into(),
+            HeaderName::Host => "host".into(),
         }
     }
 }
@@ -168,7 +170,7 @@ mod test {
 
         assert_eq!(header_map.get("key"), Some("value"));
         assert_eq!(header_map.get("KEY"), Some("value"));
-        
+
         header_map.insert("KEY", "value_2");
         assert_eq!(header_map.get("key"), Some("value_2"));
         assert_eq!(header_map.get("KEY"), Some("value_2"));

--- a/linkup/src/headers.rs
+++ b/linkup/src/headers.rs
@@ -168,5 +168,9 @@ mod test {
 
         assert_eq!(header_map.get("key"), Some("value"));
         assert_eq!(header_map.get("KEY"), Some("value"));
+        
+        header_map.insert("KEY", "value_2");
+        assert_eq!(header_map.get("key"), Some("value_2"));
+        assert_eq!(header_map.get("KEY"), Some("value_2"));
     }
 }

--- a/linkup/src/headers.rs
+++ b/linkup/src/headers.rs
@@ -4,6 +4,28 @@ use unicase::UniCase;
 
 pub struct HeaderMap(HashMap<UniCase<String>, String>);
 
+pub enum HeaderName {
+    ForwardedHost,
+    TraceParent,
+    TraceState,
+    LinkupDestination,
+    Referer,
+    Origin,
+}
+
+impl From<HeaderName> for UniCase<String> {
+    fn from(value: HeaderName) -> Self {
+        match value {
+            HeaderName::ForwardedHost => "x-forwarded-host".into(),
+            HeaderName::TraceParent => "traceparent".into(),
+            HeaderName::TraceState => "tracestate".into(),
+            HeaderName::LinkupDestination => "linkup-destination".into(),
+            HeaderName::Referer => "referer".into(),
+            HeaderName::Origin => "origin".into(),
+        }
+    }
+}
+
 impl IntoIterator for &HeaderMap {
     type Item = (UniCase<String>, String);
     type IntoIter = std::collections::hash_map::IntoIter<UniCase<String>, String>;
@@ -30,26 +52,31 @@ impl HeaderMap {
         Self(HashMap::new())
     }
 
-    pub fn contains_key(&self, key: impl ToString) -> bool {
-        self.0.contains_key(&UniCase::new(key.to_string()))
+    pub fn contains_key(&self, key: impl Into<UniCase<String>>) -> bool {
+        self.0.contains_key(&key.into())
     }
 
-    pub fn get(&self, key: impl ToString) -> Option<&str> {
-        self.0
-            .get(&UniCase::new(key.to_string()))
-            .map(String::as_ref)
+    pub fn get(&self, key: impl Into<UniCase<String>>) -> Option<&str> {
+        self.0.get(&key.into()).map(String::as_ref)
     }
 
-    pub fn get_or_default<'a>(&'a self, key: impl ToString, default: &'a str) -> &'a str {
+    pub fn get_or_default<'a>(
+        &'a self,
+        key: impl Into<UniCase<String>>,
+        default: &'a str,
+    ) -> &'a str {
         match self.get(key) {
             Some(value) => value,
             None => default,
         }
     }
 
-    pub fn insert(&mut self, key: impl ToString, value: impl ToString) -> Option<String> {
-        self.0
-            .insert(UniCase::new(key.to_string()), value.to_string())
+    pub fn insert(
+        &mut self,
+        key: impl Into<UniCase<String>>,
+        value: impl ToString,
+    ) -> Option<String> {
+        self.0.insert(key.into(), value.to_string())
     }
 
     pub fn extend(&mut self, iter: &HeaderMap) {

--- a/linkup/src/headers.rs
+++ b/linkup/src/headers.rs
@@ -95,8 +95,8 @@ impl FromIterator<(String, String)> for HeaderMap {
 }
 
 #[cfg(feature = "actix")]
-impl From<&actix_http::header::HeaderMap> for HeaderMap {
-    fn from(value: &actix_http::header::HeaderMap) -> Self {
+impl From<&actix_web::http::header::HeaderMap> for HeaderMap {
+    fn from(value: &actix_web::http::header::HeaderMap) -> Self {
         value.into_iter().collect::<HeaderMap>()
     }
 }
@@ -104,15 +104,15 @@ impl From<&actix_http::header::HeaderMap> for HeaderMap {
 #[cfg(feature = "actix")]
 impl<'a>
     FromIterator<(
-        &'a actix_http::header::HeaderName,
-        &'a actix_http::header::HeaderValue,
+        &'a actix_web::http::header::HeaderName,
+        &'a actix_web::http::header::HeaderValue,
     )> for HeaderMap
 {
     fn from_iter<
         T: IntoIterator<
             Item = (
-                &'a actix_http::header::HeaderName,
-                &'a actix_http::header::HeaderValue,
+                &'a actix_web::http::header::HeaderName,
+                &'a actix_web::http::header::HeaderValue,
             ),
         >,
     >(

--- a/linkup/src/lib.rs
+++ b/linkup/src/lib.rs
@@ -139,7 +139,7 @@ pub fn get_target_service(
         if let Some(service) = config.services.get(destination_service) {
             let target = redirect(target.clone(), &service.origin, Some(path.to_string()));
             return Some(TargetService {
-                name: destination_service.clone(),
+                name: destination_service.to_string(),
                 url: target.to_string(),
             });
         }

--- a/linkup/src/lib.rs
+++ b/linkup/src/lib.rs
@@ -5,11 +5,10 @@ mod session;
 mod session_allocator;
 
 use async_trait::async_trait;
-use headers::HeaderName;
 use rand::Rng;
 use thiserror::Error;
 
-pub use headers::HeaderMap;
+pub use headers::{HeaderMap, HeaderName};
 pub use memory_session_store::*;
 pub use name_gen::{new_session_name, random_animal, random_six_char};
 pub use session::*;
@@ -90,8 +89,6 @@ pub fn get_additional_headers(
             get_target_domain(url, session_name),
         );
     }
-
-    additional_headers.insert("host", Url::parse(&target_service.url).unwrap());
 
     additional_headers
 }

--- a/linkup/src/lib.rs
+++ b/linkup/src/lib.rs
@@ -149,25 +149,19 @@ pub fn get_target_service(
 
     // Forwarded hosts persist over the tunnel
     let forwarded_host_target = config.domains.get(&get_target_domain(
-        headers
-            .get("X-Forwarded-Host")
-            .unwrap_or(&"does-not-exist".to_string()),
+        headers.get_or_default("X-Forwarded-Host", "does-not-exist"),
         session_name,
     ));
 
     // This is more for e2e tests to work
     let referer_target = config.domains.get(&get_target_domain(
-        headers
-            .get("referer")
-            .unwrap_or(&"does-not-exist".to_string()),
+        headers.get_or_default("referer", "does-not-exist"),
         session_name,
     ));
 
     // This one is for redirects, where the referer doesn't exist
     let origin_target = config.domains.get(&get_target_domain(
-        headers
-            .get("origin")
-            .unwrap_or(&"does-not-exist".to_string()),
+        headers.get_or_default("origin", "does-not-exist"),
         session_name,
     ));
 

--- a/linkup/src/lib.rs
+++ b/linkup/src/lib.rs
@@ -210,7 +210,6 @@ pub fn get_target_service(
                 name: service_name,
                 url: target.to_string(),
             });
-            // return Some((service_name, String::from(target)));
         }
     }
 

--- a/linkup/src/lib.rs
+++ b/linkup/src/lib.rs
@@ -87,14 +87,7 @@ pub fn get_additional_headers(
         additional_headers.insert("x-forwarded-host", get_target_domain(url, session_name));
     }
 
-    additional_headers.insert(
-        "host",
-        Url::parse(&target_service.url)
-            .unwrap()
-            .host_str()
-            .unwrap()
-            .to_string(),
-    );
+    additional_headers.insert("host", Url::parse(&target_service.url).unwrap());
 
     additional_headers
 }

--- a/linkup/src/session_allocator.rs
+++ b/linkup/src/session_allocator.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
 use crate::{
-    extract_tracestate_session, first_subdomain, random_animal, random_six_char, session_to_json,
-    ConfigError, HeaderMap, NameKind, Session, SessionError, StringStore,
+    extract_tracestate_session, first_subdomain, headers::HeaderName, random_animal,
+    random_six_char, session_to_json, ConfigError, HeaderMap, NameKind, Session, SessionError,
+    StringStore,
 };
 
 pub struct SessionAllocator {
@@ -24,7 +25,7 @@ impl SessionAllocator {
             return Ok((url_name, config));
         }
 
-        if let Some(forwarded_host) = headers.get("x-forwarded-host") {
+        if let Some(forwarded_host) = headers.get(HeaderName::ForwardedHost) {
             let forwarded_host_name = first_subdomain(forwarded_host);
             if let Some(config) = self
                 .get_session_config(forwarded_host_name.to_string())

--- a/linkup/src/session_allocator.rs
+++ b/linkup/src/session_allocator.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use crate::{
     extract_tracestate_session, first_subdomain, random_animal, random_six_char, session_to_json,
-    ConfigError, NameKind, Session, SessionError, StringStore,
+    ConfigError, HeaderMap, NameKind, Session, SessionError, StringStore,
 };
 
 pub struct SessionAllocator {
@@ -16,10 +16,10 @@ impl SessionAllocator {
 
     pub async fn get_request_session(
         &self,
-        url: String,
-        headers: HashMap<String, String>,
+        url: &str,
+        headers: &HeaderMap,
     ) -> Result<(String, Session), SessionError> {
-        let url_name = first_subdomain(&url);
+        let url_name = first_subdomain(url);
         if let Some(config) = self.get_session_config(url_name.to_string()).await? {
             return Ok((url_name, config));
         }
@@ -55,7 +55,7 @@ impl SessionAllocator {
             }
         }
 
-        Err(SessionError::NoSuchSession(url))
+        Err(SessionError::NoSuchSession(url.to_string()))
     }
 
     pub async fn store_session(

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-linkup = { path = "../linkup" }
+linkup = { path = "../linkup", features = ["worker"]}
 worker = "0.0.18"
 reqwest = "0.11.22"
 http = "0.2.9"

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -124,7 +124,7 @@ async fn linkup_request_handler(mut req: Request, sessions: SessionAllocator) ->
     headers.extend(&extra_headers);
     let response_result = client
         .request(method, &target_service.url)
-        .headers((&headers).into())
+        .headers(headers.into())
         .body(body_bytes)
         .send()
         .await;

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -3,20 +3,18 @@
 //   For more info check: https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
 #![allow(clippy::arc_with_non_send_sync)]
 
-use regex::Regex;
-use std::{collections::HashMap, sync::Arc};
-use ws::linkup_ws_handler;
-
+use http_util::*;
 use kv_store::CfWorkerStringStore;
-use linkup::*;
+use linkup::{HeaderMap as LinkupHeaderMap, *};
+use regex::Regex;
+use std::sync::Arc;
 use worker::*;
+use ws::linkup_ws_handler;
 
 mod http_util;
 mod kv_store;
 mod utils;
 mod ws;
-
-use http_util::*;
 
 async fn linkup_session_handler(mut req: Request, sessions: SessionAllocator) -> Result<Response> {
     let body_bytes = match req.bytes().await {
@@ -92,14 +90,10 @@ async fn linkup_request_handler(mut req: Request, sessions: SessionAllocator) ->
         Err(_) => return plaintext_error("Bad or missing request url", 400),
     };
 
-    let headers = req
-        .headers()
-        .clone()
-        .entries()
-        .collect::<HashMap<String, String>>();
+    let mut headers = LinkupHeaderMap::from_worker_request(&req);
 
     let (session_name, config) =
-        match sessions.get_request_session(url.clone(), headers.clone()).await {
+        match sessions.get_request_session(&url, &headers).await {
             Ok(result) => result,
             Err(_) => return plaintext_error("Could not find a linkup session for this request. Use a linkup subdomain or context headers like Referer/tracestate", 422),
         };
@@ -114,12 +108,12 @@ async fn linkup_request_handler(mut req: Request, sessions: SessionAllocator) ->
     };
 
     let (dest_service_name, destination_url) =
-        match get_target_service(url.clone(), headers.clone(), &config, &session_name) {
+        match get_target_service(&url, &headers, &config, &session_name) {
             Some(result) => result,
             None => return plaintext_error("No target URL for request", 422),
         };
 
-    let extra_headers = get_additional_headers(url, &headers, &session_name, &dest_service_name);
+    let extra_headers = get_additional_headers(&url, &headers, &session_name, &dest_service_name);
 
     let method = match convert_cf_method_to_reqwest(&req.method()) {
         Ok(method) => method,
@@ -128,9 +122,10 @@ async fn linkup_request_handler(mut req: Request, sessions: SessionAllocator) ->
 
     // // Proxy the request using the destination_url and the merged headers
     let client = reqwest::Client::new();
+    headers.extend(&extra_headers);
     let response_result = client
         .request(method, &destination_url)
-        .headers(merge_headers(headers, extra_headers))
+        .headers((&headers).into())
         .body(body_bytes)
         .send()
         .await;
@@ -141,7 +136,7 @@ async fn linkup_request_handler(mut req: Request, sessions: SessionAllocator) ->
     };
 
     let mut cf_resp =
-        convert_reqwest_response_to_cf(response, additional_response_headers()).await?;
+        convert_reqwest_response_to_cf(response, &additional_response_headers()).await?;
 
     cf_resp = set_cached_req(&req, cf_resp, config.cache_routes).await?;
 

--- a/worker/src/ws.rs
+++ b/worker/src/ws.rs
@@ -14,7 +14,7 @@ pub async fn linkup_ws_handler(req: Request, sessions: SessionAllocator) -> Resu
         Err(_) => return plaintext_error("Bad or missing request url", 400),
     };
 
-    let mut headers = req.headers().clone().entries().collect::<LinkupHeaderMap>();
+    let mut headers = LinkupHeaderMap::from_worker_request(&req);
 
     let (session_name, config) =
         match sessions.get_request_session(&url, &headers).await {

--- a/worker/src/ws.rs
+++ b/worker/src/ws.rs
@@ -22,16 +22,15 @@ pub async fn linkup_ws_handler(req: Request, sessions: SessionAllocator) -> Resu
             Err(_) => return plaintext_error("Could not find a linkup session for this request. Use a linkup subdomain or context headers like Referer/tracestate", 422),
         };
 
-    let (dest_service_name, destination_url) =
-        match get_target_service(&url, &headers, &config, &session_name) {
-            Some(result) => result,
-            None => return plaintext_error("No target URL for request", 422),
-        };
+    let target_service = match get_target_service(&url, &headers, &config, &session_name) {
+        Some(result) => result,
+        None => return plaintext_error("No target URL for request", 422),
+    };
 
-    let extra_headers = get_additional_headers(&url, &headers, &session_name, &dest_service_name);
+    let extra_headers = get_additional_headers(&url, &headers, &session_name, &target_service);
     headers.extend(&extra_headers);
 
-    let dest_ws_res = websocket_connect(&destination_url, &headers).await;
+    let dest_ws_res = websocket_connect(&target_service.url, &headers).await;
     let dest_ws = match dest_ws_res {
         Ok(ws) => ws,
         Err(e) => {

--- a/worker/src/ws.rs
+++ b/worker/src/ws.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use linkup::*;
+use linkup::{HeaderMap as LinkupHeaderMap, *};
 use worker::*;
 
 use futures::{
@@ -16,28 +14,24 @@ pub async fn linkup_ws_handler(req: Request, sessions: SessionAllocator) -> Resu
         Err(_) => return plaintext_error("Bad or missing request url", 400),
     };
 
-    let mut headers = req
-        .headers()
-        .clone()
-        .entries()
-        .collect::<HashMap<String, String>>();
+    let mut headers = req.headers().clone().entries().collect::<LinkupHeaderMap>();
 
     let (session_name, config) =
-        match sessions.get_request_session(url.clone(), headers.clone()).await {
+        match sessions.get_request_session(&url, &headers).await {
             Ok(result) => result,
             Err(_) => return plaintext_error("Could not find a linkup session for this request. Use a linkup subdomain or context headers like Referer/tracestate", 422),
         };
 
     let (dest_service_name, destination_url) =
-        match get_target_service(url.clone(), headers.clone(), &config, &session_name) {
+        match get_target_service(&url, &headers, &config, &session_name) {
             Some(result) => result,
             None => return plaintext_error("No target URL for request", 422),
         };
 
-    let extra_headers = get_additional_headers(url, &headers, &session_name, &dest_service_name);
-    headers.extend(extra_headers);
+    let extra_headers = get_additional_headers(&url, &headers, &session_name, &dest_service_name);
+    headers.extend(&extra_headers);
 
-    let dest_ws_res = websocket_connect(&destination_url, headers).await;
+    let dest_ws_res = websocket_connect(&destination_url, &headers).await;
     let dest_ws = match dest_ws_res {
         Ok(ws) => ws,
         Err(e) => {
@@ -145,10 +139,7 @@ fn forward_ws_event(
     }
 }
 
-async fn websocket_connect(
-    url: &str,
-    additional_headers: HashMap<String, String>,
-) -> Result<WebSocket> {
+async fn websocket_connect(url: &str, additional_headers: &LinkupHeaderMap) -> Result<WebSocket> {
     let mut proper_url = match url.parse::<Url>() {
         Ok(url) => url,
         Err(_) => return Err(Error::RustError("invalid url".into())),
@@ -164,10 +155,10 @@ async fn websocket_connect(
 
     proper_url.set_scheme(&scheme).unwrap();
 
-    let mut headers = Headers::new();
-    additional_headers.iter().for_each(|(k, v)| {
+    let mut headers = worker::Headers::new();
+    additional_headers.into_iter().for_each(|(k, v)| {
         headers
-            .append(k, v)
+            .append(k.as_str(), v.as_str())
             .expect("could not append header to websocket request");
     });
     headers.set("upgrade", "websocket")?;


### PR DESCRIPTION
### Description
This should improve the ergonomics around handling headers and change its types between different libraries.

### Notable changes
- Introduce [`unicase`](https://docs.rs/unicase/latest/unicase/) to `linkup` so that headers can be handled with case insensitive.
- Add feature flags to `linkup`.
    - `reqwest`: add `reqwest` as dependency and implement helper methods around `linkup::HeaderMap` to work with `reqwest` headers. 
    - `actix`: add `actix-web` and `actix-http` as dependencies and implement helper methods around `linkup::HeaderMap` to work with `actix` request and headers. 
    - `worker`: add `worker` as dependency and implement helper methods around `linkup::HeaderMap` to work with `worker` request and headers.
- Changes from `.clone` to use reference where applicable.
- Move `Host` header definition into the `.get_additional_headers` as suggested by TODO.
- Clearer differentiation between `linkup::HeaderMap`, `actix_http::header::HeaderMap` and `reqwest::header::HeaderMap`.
- Introduce `linkup::HeaderName` to avoid having header names as raw strings.

### Interesting resources
- [Newtype Pattern](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#using-the-newtype-pattern-to-implement-external-traits-on-external-types)