### PR TITLE
refactor: remove unnecessary Arc in SessionAllocator

### DIFF
--- a/linkup-cli/src/local_server.rs
+++ b/linkup-cli/src/local_server.rs
@@ -22,8 +22,6 @@ async fn linkup_config_handler(
     string_store: web::Data<MemoryStringStore>,
     req_body: web::Bytes,
 ) -> impl Responder {
-    let sessions = SessionAllocator::new(string_store.as_ref());
-
     let input_json_conf = match String::from_utf8(req_body.to_vec()) {
         Ok(input_json_conf) => input_json_conf,
         Err(_) => {
@@ -35,6 +33,7 @@ async fn linkup_config_handler(
 
     match update_session_req_from_json(input_json_conf) {
         Ok((desired_name, server_conf)) => {
+            let sessions = SessionAllocator::new(string_store.as_ref());
             let session_name = sessions
                 .store_session(server_conf, NameKind::Animal, desired_name)
                 .await;

--- a/linkup-cli/src/local_server.rs
+++ b/linkup-cli/src/local_server.rs
@@ -22,8 +22,6 @@ async fn linkup_config_handler(
     string_store: web::Data<MemoryStringStore>,
     req_body: web::Bytes,
 ) -> impl Responder {
-    let sessions = SessionAllocator::new(string_store.into_inner());
-
     let input_json_conf = match String::from_utf8(req_body.to_vec()) {
         Ok(input_json_conf) => input_json_conf,
         Err(_) => {
@@ -35,9 +33,13 @@ async fn linkup_config_handler(
 
     match update_session_req_from_json(input_json_conf) {
         Ok((desired_name, server_conf)) => {
-            let session_name = sessions
-                .store_session(server_conf, NameKind::Animal, desired_name)
-                .await;
+            let session_name = store_session(
+                string_store.as_ref(),
+                server_conf,
+                NameKind::Animal,
+                desired_name,
+            )
+            .await;
             match session_name {
                 Ok(session_name) => HttpResponse::Ok().body(session_name),
                 Err(e) => HttpResponse::InternalServerError()
@@ -59,12 +61,10 @@ async fn linkup_ws_request_handler(
     req: HttpRequest,
     req_stream: web::Payload,
 ) -> impl Responder {
-    let sessions = SessionAllocator::new(string_store.into_inner());
-
     let url = format!("http://localhost:{}{}", LINKUP_LOCALSERVER_PORT, req.uri());
     let mut headers = LinkupHeaderMap::from_actix_request(&req);
 
-    let session_result = sessions.get_request_session(&url, &headers).await;
+    let session_result = get_request_session(string_store.as_ref(), &url, &headers).await;
 
     if session_result.is_err() {
         println!("Failed to get session: {:?}", session_result);
@@ -161,12 +161,10 @@ async fn linkup_request_handler(
     req: HttpRequest,
     req_body: web::Bytes,
 ) -> impl Responder {
-    let sessions = SessionAllocator::new(string_store.into_inner());
-
     let url = format!("http://localhost:{}{}", LINKUP_LOCALSERVER_PORT, req.uri());
     let mut headers = LinkupHeaderMap::from_actix_request(&req);
 
-    let session_result = sessions.get_request_session(&url, &headers).await;
+    let session_result = get_request_session(string_store.as_ref(), &url, &headers).await;
 
     if session_result.is_err() {
         println!("Failed to get session: {:?}", session_result);

--- a/linkup/src/lib.rs
+++ b/linkup/src/lib.rs
@@ -324,7 +324,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_request_session_by_subdomain() {
         let string_store = MemoryStringStore::new();
-        let session_allocator = SessionAllocator::new(&string_store);
+        let sessions = SessionAllocator::new(&string_store);
 
         let config_value: serde_json::Value = serde_json::from_str(CONF_STR).unwrap();
         let config: Session = config_value.try_into().unwrap();
@@ -455,7 +455,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_target_url() {
         let string_store = MemoryStringStore::new();
-        let session_allocator = SessionAllocator::new(&string_store);
+        let sessions = SessionAllocator::new(&string_store);
 
         let input_config_value: serde_json::Value = serde_json::from_str(CONF_STR).unwrap();
         let input_config: Session = input_config_value.try_into().unwrap();
@@ -545,7 +545,7 @@ mod tests {
     #[tokio::test]
     async fn test_repeatable_rewritten_routes() {
         let string_store = MemoryStringStore::new();
-        let session_allocator = SessionAllocator::new(&string_store);
+        let sessions = SessionAllocator::new(&string_store);
 
         let input_config_value: serde_json::Value = serde_json::from_str(CONF_STR).unwrap();
         let input_config: Session = input_config_value.try_into().unwrap();

--- a/linkup/src/lib.rs
+++ b/linkup/src/lib.rs
@@ -329,13 +329,13 @@ mod tests {
         let config_value: serde_json::Value = serde_json::from_str(CONF_STR).unwrap();
         let config: Session = config_value.try_into().unwrap();
 
-        let name = session_allocator
+        let name = sessions
             .store_session(config, NameKind::Animal, "".to_string())
             .await
             .unwrap();
 
         // Normal subdomain
-        session_allocator
+        sessions
             .get_request_session(&format!("{}.example.com", name), &HeaderMap::new())
             .await
             .unwrap();
@@ -344,7 +344,7 @@ mod tests {
         let mut referer_headers = HeaderMap::new();
         // TODO check header capitalization
         referer_headers.insert("referer", format!("http://{}.example.com", name));
-        session_allocator
+        sessions
             .get_request_session("example.com", &referer_headers)
             .await
             .unwrap();
@@ -352,7 +352,7 @@ mod tests {
         // Origin
         let mut origin_headers = HeaderMap::new();
         origin_headers.insert("origin", format!("http://{}.example.com", name));
-        session_allocator
+        sessions
             .get_request_session("example.com", &origin_headers)
             .await
             .unwrap();
@@ -363,14 +363,14 @@ mod tests {
             HeaderName::TraceState,
             format!("some-other=xyz,linkup-session={}", name),
         );
-        session_allocator
+        sessions
             .get_request_session("example.com", &trace_headers)
             .await
             .unwrap();
 
         let mut trace_headers_two = HeaderMap::new();
         trace_headers_two.insert(HeaderName::TraceState, format!("linkup-session={}", name));
-        session_allocator
+        sessions
             .get_request_session("example.com", &trace_headers_two)
             .await
             .unwrap();
@@ -460,12 +460,12 @@ mod tests {
         let input_config_value: serde_json::Value = serde_json::from_str(CONF_STR).unwrap();
         let input_config: Session = input_config_value.try_into().unwrap();
 
-        let name = session_allocator
+        let name = sessions
             .store_session(input_config, NameKind::Animal, "".to_string())
             .await
             .unwrap();
 
-        let (name, config) = session_allocator
+        let (name, config) = sessions
             .get_request_session(&format!("{}.example.com", name), &HeaderMap::new())
             .await
             .unwrap();
@@ -550,12 +550,12 @@ mod tests {
         let input_config_value: serde_json::Value = serde_json::from_str(CONF_STR).unwrap();
         let input_config: Session = input_config_value.try_into().unwrap();
 
-        let name = session_allocator
+        let name = sessions
             .store_session(input_config, NameKind::Animal, "".to_string())
             .await
             .unwrap();
 
-        let (name, config) = session_allocator
+        let (name, config) = sessions
             .get_request_session(&format!("{}.example.com", name), &HeaderMap::new())
             .await
             .unwrap();

--- a/linkup/src/session_allocator.rs
+++ b/linkup/src/session_allocator.rs
@@ -1,159 +1,153 @@
-use std::sync::Arc;
-
 use crate::{
     extract_tracestate_session, first_subdomain, headers::HeaderName, random_animal,
     random_six_char, session_to_json, ConfigError, HeaderMap, NameKind, Session, SessionError,
     StringStore,
 };
 
-pub struct SessionAllocator {
-    store: Arc<dyn StringStore>,
+pub async fn get_request_session(
+    string_store: &impl StringStore,
+    url: &str,
+    headers: &HeaderMap,
+) -> Result<(String, Session), SessionError> {
+    let url_name = first_subdomain(url);
+    if let Some(config) = get_session_config(string_store, url_name.to_string()).await? {
+        return Ok((url_name, config));
+    }
+
+    if let Some(forwarded_host) = headers.get(HeaderName::ForwardedHost) {
+        let forwarded_host_name = first_subdomain(forwarded_host);
+        if let Some(config) =
+            get_session_config(string_store, forwarded_host_name.to_string()).await?
+        {
+            return Ok((forwarded_host_name, config));
+        }
+    }
+
+    if let Some(referer) = headers.get("referer") {
+        let referer_name = first_subdomain(referer);
+        if let Some(config) = get_session_config(string_store, referer_name.to_string()).await? {
+            return Ok((referer_name, config));
+        }
+    }
+
+    if let Some(origin) = headers.get("origin") {
+        let origin_name = first_subdomain(origin);
+        if let Some(config) = get_session_config(string_store, origin_name.to_string()).await? {
+            return Ok((origin_name, config));
+        }
+    }
+
+    if let Some(tracestate) = headers.get("tracestate") {
+        let trace_name = extract_tracestate_session(tracestate);
+        if let Some(config) = get_session_config(string_store, trace_name.to_string()).await? {
+            return Ok((trace_name, config));
+        }
+    }
+
+    Err(SessionError::NoSuchSession(url.to_string()))
 }
 
-impl SessionAllocator {
-    pub fn new(store: Arc<dyn StringStore>) -> Self {
-        Self { store }
+async fn get_session_config(
+    string_store: &impl StringStore,
+    name: String,
+) -> Result<Option<Session>, SessionError> {
+    let value = match string_store.get(name).await {
+        Ok(Some(v)) => v,
+        Ok(None) => return Ok(None),
+        Err(e) => return Err(e),
+    };
+
+    let config_value: serde_json::Value =
+        serde_json::from_str(&value).map_err(|e| SessionError::ConfigErr(e.to_string()))?;
+
+    let session_config = config_value
+        .try_into()
+        .map_err(|e: ConfigError| SessionError::ConfigErr(e.to_string()))?;
+
+    Ok(Some(session_config))
+}
+
+pub async fn store_session(
+    string_store: &impl StringStore,
+    config: Session,
+    name_kind: NameKind,
+    desired_name: String,
+) -> Result<String, SessionError> {
+    let name = choose_name(
+        string_store,
+        desired_name,
+        config.session_token.clone(),
+        name_kind,
+    )
+    .await?;
+
+    let config_str = session_to_json(config);
+
+    string_store.put(name.clone(), config_str).await?;
+
+    Ok(name)
+}
+
+async fn choose_name(
+    string_store: &impl StringStore,
+    desired_name: String,
+    session_token: String,
+    name_kind: NameKind,
+) -> Result<String, SessionError> {
+    if desired_name.is_empty() {
+        return new_session_name(string_store, name_kind, desired_name).await;
     }
 
-    pub async fn get_request_session(
-        &self,
-        url: &str,
-        headers: &HeaderMap,
-    ) -> Result<(String, Session), SessionError> {
-        let url_name = first_subdomain(url);
-        if let Some(config) = self.get_session_config(url_name.to_string()).await? {
-            return Ok((url_name, config));
+    if let Some(session) = get_session_config(string_store, desired_name.clone()).await? {
+        if session.session_token == session_token {
+            return Ok(desired_name);
         }
-
-        if let Some(forwarded_host) = headers.get(HeaderName::ForwardedHost) {
-            let forwarded_host_name = first_subdomain(forwarded_host);
-            if let Some(config) = self
-                .get_session_config(forwarded_host_name.to_string())
-                .await?
-            {
-                return Ok((forwarded_host_name, config));
-            }
-        }
-
-        if let Some(referer) = headers.get("referer") {
-            let referer_name = first_subdomain(referer);
-            if let Some(config) = self.get_session_config(referer_name.to_string()).await? {
-                return Ok((referer_name, config));
-            }
-        }
-
-        if let Some(origin) = headers.get("origin") {
-            let origin_name = first_subdomain(origin);
-            if let Some(config) = self.get_session_config(origin_name.to_string()).await? {
-                return Ok((origin_name, config));
-            }
-        }
-
-        if let Some(tracestate) = headers.get("tracestate") {
-            let trace_name = extract_tracestate_session(tracestate);
-            if let Some(config) = self.get_session_config(trace_name.to_string()).await? {
-                return Ok((trace_name, config));
-            }
-        }
-
-        Err(SessionError::NoSuchSession(url.to_string()))
     }
 
-    pub async fn store_session(
-        &self,
-        config: Session,
-        name_kind: NameKind,
-        desired_name: String,
-    ) -> Result<String, SessionError> {
-        let name = self
-            .choose_name(desired_name, config.session_token.clone(), name_kind)
-            .await?;
+    new_session_name(string_store, name_kind, desired_name).await
+}
 
-        let config_str = session_to_json(config);
+async fn new_session_name(
+    string_store: &impl StringStore,
+    name_kind: NameKind,
+    desired_name: String,
+) -> Result<String, SessionError> {
+    let mut key = String::new();
 
-        self.store.put(name.clone(), config_str).await?;
-
-        Ok(name)
+    if !desired_name.is_empty() && !string_store.exists(desired_name.clone()).await? {
+        key = desired_name;
     }
 
-    async fn choose_name(
-        &self,
-        desired_name: String,
-        session_token: String,
-        name_kind: NameKind,
-    ) -> Result<String, SessionError> {
-        if desired_name.is_empty() {
-            return self.new_session_name(name_kind, desired_name).await;
-        }
+    if key.is_empty() {
+        let mut tried_animal_key = false;
+        loop {
+            let generated_key = if !tried_animal_key && name_kind == NameKind::Animal {
+                tried_animal_key = true;
+                generate_unique_animal_key(string_store, 20).await?
+            } else {
+                random_six_char()
+            };
 
-        if let Some(session) = self.get_session_config(desired_name.clone()).await? {
-            if session.session_token == session_token {
-                return Ok(desired_name);
+            if !string_store.exists(generated_key.clone()).await? {
+                key = generated_key;
+                break;
             }
         }
-
-        self.new_session_name(name_kind, desired_name).await
     }
 
-    async fn get_session_config(&self, name: String) -> Result<Option<Session>, SessionError> {
-        let value = match self.store.get(name).await {
-            Ok(Some(v)) => v,
-            Ok(None) => return Ok(None),
-            Err(e) => return Err(e),
-        };
+    Ok(key)
+}
 
-        let config_value: serde_json::Value =
-            serde_json::from_str(&value).map_err(|e| SessionError::ConfigErr(e.to_string()))?;
-
-        let session_config = config_value
-            .try_into()
-            .map_err(|e: ConfigError| SessionError::ConfigErr(e.to_string()))?;
-
-        Ok(Some(session_config))
-    }
-
-    async fn new_session_name(
-        &self,
-        name_kind: NameKind,
-        desired_name: String,
-    ) -> Result<String, SessionError> {
-        let mut key = String::new();
-
-        if !desired_name.is_empty() && !self.store.exists(desired_name.clone()).await? {
-            key = desired_name;
+async fn generate_unique_animal_key(
+    string_store: &impl StringStore,
+    max_attempts: usize,
+) -> Result<String, SessionError> {
+    for _ in 0..max_attempts {
+        let generated_key = random_animal();
+        if !string_store.exists(generated_key.clone()).await? {
+            return Ok(generated_key);
         }
-
-        if key.is_empty() {
-            let mut tried_animal_key = false;
-            loop {
-                let generated_key = if !tried_animal_key && name_kind == NameKind::Animal {
-                    tried_animal_key = true;
-                    self.generate_unique_animal_key(20).await?
-                } else {
-                    random_six_char()
-                };
-
-                if !self.store.exists(generated_key.clone()).await? {
-                    key = generated_key;
-                    break;
-                }
-            }
-        }
-
-        Ok(key)
     }
-
-    async fn generate_unique_animal_key(
-        &self,
-        max_attempts: usize,
-    ) -> Result<String, SessionError> {
-        for _ in 0..max_attempts {
-            let generated_key = random_animal();
-            if !self.store.exists(generated_key.clone()).await? {
-                return Ok(generated_key);
-            }
-        }
-        // Fallback to SixChar logic
-        Ok(random_six_char())
-    }
+    // Fallback to SixChar logic
+    Ok(random_six_char())
 }

--- a/linkup/src/session_allocator.rs
+++ b/linkup/src/session_allocator.rs
@@ -4,150 +4,154 @@ use crate::{
     StringStore,
 };
 
-pub async fn get_request_session(
-    string_store: &impl StringStore,
-    url: &str,
-    headers: &HeaderMap,
-) -> Result<(String, Session), SessionError> {
-    let url_name = first_subdomain(url);
-    if let Some(config) = get_session_config(string_store, url_name.to_string()).await? {
-        return Ok((url_name, config));
-    }
-
-    if let Some(forwarded_host) = headers.get(HeaderName::ForwardedHost) {
-        let forwarded_host_name = first_subdomain(forwarded_host);
-        if let Some(config) =
-            get_session_config(string_store, forwarded_host_name.to_string()).await?
-        {
-            return Ok((forwarded_host_name, config));
-        }
-    }
-
-    if let Some(referer) = headers.get("referer") {
-        let referer_name = first_subdomain(referer);
-        if let Some(config) = get_session_config(string_store, referer_name.to_string()).await? {
-            return Ok((referer_name, config));
-        }
-    }
-
-    if let Some(origin) = headers.get("origin") {
-        let origin_name = first_subdomain(origin);
-        if let Some(config) = get_session_config(string_store, origin_name.to_string()).await? {
-            return Ok((origin_name, config));
-        }
-    }
-
-    if let Some(tracestate) = headers.get("tracestate") {
-        let trace_name = extract_tracestate_session(tracestate);
-        if let Some(config) = get_session_config(string_store, trace_name.to_string()).await? {
-            return Ok((trace_name, config));
-        }
-    }
-
-    Err(SessionError::NoSuchSession(url.to_string()))
+pub struct SessionAllocator<'a> {
+    store: &'a dyn StringStore,
 }
 
-async fn get_session_config(
-    string_store: &impl StringStore,
-    name: String,
-) -> Result<Option<Session>, SessionError> {
-    let value = match string_store.get(name).await {
-        Ok(Some(v)) => v,
-        Ok(None) => return Ok(None),
-        Err(e) => return Err(e),
-    };
-
-    let config_value: serde_json::Value =
-        serde_json::from_str(&value).map_err(|e| SessionError::ConfigErr(e.to_string()))?;
-
-    let session_config = config_value
-        .try_into()
-        .map_err(|e: ConfigError| SessionError::ConfigErr(e.to_string()))?;
-
-    Ok(Some(session_config))
-}
-
-pub async fn store_session(
-    string_store: &impl StringStore,
-    config: Session,
-    name_kind: NameKind,
-    desired_name: String,
-) -> Result<String, SessionError> {
-    let name = choose_name(
-        string_store,
-        desired_name,
-        config.session_token.clone(),
-        name_kind,
-    )
-    .await?;
-
-    let config_str = session_to_json(config);
-
-    string_store.put(name.clone(), config_str).await?;
-
-    Ok(name)
-}
-
-async fn choose_name(
-    string_store: &impl StringStore,
-    desired_name: String,
-    session_token: String,
-    name_kind: NameKind,
-) -> Result<String, SessionError> {
-    if desired_name.is_empty() {
-        return new_session_name(string_store, name_kind, desired_name).await;
+impl<'a> SessionAllocator<'a> {
+    pub fn new(store: &'a dyn StringStore) -> Self {
+        Self { store }
     }
 
-    if let Some(session) = get_session_config(string_store, desired_name.clone()).await? {
-        if session.session_token == session_token {
-            return Ok(desired_name);
+    pub async fn get_request_session(
+        &self,
+        url: &str,
+        headers: &HeaderMap,
+    ) -> Result<(String, Session), SessionError> {
+        let url_name = first_subdomain(url);
+        if let Some(config) = self.get_session_config(url_name.to_string()).await? {
+            return Ok((url_name, config));
         }
-    }
 
-    new_session_name(string_store, name_kind, desired_name).await
-}
-
-async fn new_session_name(
-    string_store: &impl StringStore,
-    name_kind: NameKind,
-    desired_name: String,
-) -> Result<String, SessionError> {
-    let mut key = String::new();
-
-    if !desired_name.is_empty() && !string_store.exists(desired_name.clone()).await? {
-        key = desired_name;
-    }
-
-    if key.is_empty() {
-        let mut tried_animal_key = false;
-        loop {
-            let generated_key = if !tried_animal_key && name_kind == NameKind::Animal {
-                tried_animal_key = true;
-                generate_unique_animal_key(string_store, 20).await?
-            } else {
-                random_six_char()
-            };
-
-            if !string_store.exists(generated_key.clone()).await? {
-                key = generated_key;
-                break;
+        if let Some(forwarded_host) = headers.get(HeaderName::ForwardedHost) {
+            let forwarded_host_name = first_subdomain(forwarded_host);
+            if let Some(config) = self
+                .get_session_config(forwarded_host_name.to_string())
+                .await?
+            {
+                return Ok((forwarded_host_name, config));
             }
         }
-    }
 
-    Ok(key)
-}
-
-async fn generate_unique_animal_key(
-    string_store: &impl StringStore,
-    max_attempts: usize,
-) -> Result<String, SessionError> {
-    for _ in 0..max_attempts {
-        let generated_key = random_animal();
-        if !string_store.exists(generated_key.clone()).await? {
-            return Ok(generated_key);
+        if let Some(referer) = headers.get("referer") {
+            let referer_name = first_subdomain(referer);
+            if let Some(config) = self.get_session_config(referer_name.to_string()).await? {
+                return Ok((referer_name, config));
+            }
         }
+
+        if let Some(origin) = headers.get("origin") {
+            let origin_name = first_subdomain(origin);
+            if let Some(config) = self.get_session_config(origin_name.to_string()).await? {
+                return Ok((origin_name, config));
+            }
+        }
+
+        if let Some(tracestate) = headers.get("tracestate") {
+            let trace_name = extract_tracestate_session(tracestate);
+            if let Some(config) = self.get_session_config(trace_name.to_string()).await? {
+                return Ok((trace_name, config));
+            }
+        }
+
+        Err(SessionError::NoSuchSession(url.to_string()))
     }
-    // Fallback to SixChar logic
-    Ok(random_six_char())
+
+    async fn get_session_config(&self, name: String) -> Result<Option<Session>, SessionError> {
+        let value = match self.store.get(name).await {
+            Ok(Some(v)) => v,
+            Ok(None) => return Ok(None),
+            Err(e) => return Err(e),
+        };
+
+        let config_value: serde_json::Value =
+            serde_json::from_str(&value).map_err(|e| SessionError::ConfigErr(e.to_string()))?;
+
+        let session_config = config_value
+            .try_into()
+            .map_err(|e: ConfigError| SessionError::ConfigErr(e.to_string()))?;
+
+        Ok(Some(session_config))
+    }
+
+    pub async fn store_session(
+        &self,
+        config: Session,
+        name_kind: NameKind,
+        desired_name: String,
+    ) -> Result<String, SessionError> {
+        let name = self
+            .choose_name(desired_name, config.session_token.clone(), name_kind)
+            .await?;
+
+        let config_str = session_to_json(config);
+
+        self.store.put(name.clone(), config_str).await?;
+
+        Ok(name)
+    }
+
+    async fn choose_name(
+        &self,
+        desired_name: String,
+        session_token: String,
+        name_kind: NameKind,
+    ) -> Result<String, SessionError> {
+        if desired_name.is_empty() {
+            return self.new_session_name(name_kind, desired_name).await;
+        }
+
+        if let Some(session) = self.get_session_config(desired_name.clone()).await? {
+            if session.session_token == session_token {
+                return Ok(desired_name);
+            }
+        }
+
+        self.new_session_name(name_kind, desired_name).await
+    }
+
+    async fn new_session_name(
+        &self,
+        name_kind: NameKind,
+        desired_name: String,
+    ) -> Result<String, SessionError> {
+        let mut key = String::new();
+
+        if !desired_name.is_empty() && !self.store.exists(desired_name.clone()).await? {
+            key = desired_name;
+        }
+
+        if key.is_empty() {
+            let mut tried_animal_key = false;
+            loop {
+                let generated_key = if !tried_animal_key && name_kind == NameKind::Animal {
+                    tried_animal_key = true;
+                    self.generate_unique_animal_key(20).await?
+                } else {
+                    random_six_char()
+                };
+
+                if !self.store.exists(generated_key.clone()).await? {
+                    key = generated_key;
+                    break;
+                }
+            }
+        }
+
+        Ok(key)
+    }
+
+    async fn generate_unique_animal_key(
+        &self,
+        max_attempts: usize,
+    ) -> Result<String, SessionError> {
+        for _ in 0..max_attempts {
+            let generated_key = random_animal();
+            if !self.store.exists(generated_key.clone()).await? {
+                return Ok(generated_key);
+            }
+        }
+        // Fallback to SixChar logic
+        Ok(random_six_char())
+    }
 }

--- a/linkup/src/session_allocator.rs
+++ b/linkup/src/session_allocator.rs
@@ -57,23 +57,6 @@ impl<'a> SessionAllocator<'a> {
         Err(SessionError::NoSuchSession(url.to_string()))
     }
 
-    async fn get_session_config(&self, name: String) -> Result<Option<Session>, SessionError> {
-        let value = match self.store.get(name).await {
-            Ok(Some(v)) => v,
-            Ok(None) => return Ok(None),
-            Err(e) => return Err(e),
-        };
-
-        let config_value: serde_json::Value =
-            serde_json::from_str(&value).map_err(|e| SessionError::ConfigErr(e.to_string()))?;
-
-        let session_config = config_value
-            .try_into()
-            .map_err(|e: ConfigError| SessionError::ConfigErr(e.to_string()))?;
-
-        Ok(Some(session_config))
-    }
-
     pub async fn store_session(
         &self,
         config: Session,
@@ -108,6 +91,23 @@ impl<'a> SessionAllocator<'a> {
         }
 
         self.new_session_name(name_kind, desired_name).await
+    }
+
+    async fn get_session_config(&self, name: String) -> Result<Option<Session>, SessionError> {
+        let value = match self.store.get(name).await {
+            Ok(Some(v)) => v,
+            Ok(None) => return Ok(None),
+            Err(e) => return Err(e),
+        };
+
+        let config_value: serde_json::Value =
+            serde_json::from_str(&value).map_err(|e| SessionError::ConfigErr(e.to_string()))?;
+
+        let session_config = config_value
+            .try_into()
+            .map_err(|e: ConfigError| SessionError::ConfigErr(e.to_string()))?;
+
+        Ok(Some(session_config))
     }
 
     async fn new_session_name(

--- a/worker/src/ws.rs
+++ b/worker/src/ws.rs
@@ -8,7 +8,7 @@ use futures::{
 
 use crate::http_util::plaintext_error;
 
-pub async fn linkup_ws_handler(req: Request, sessions: SessionAllocator) -> Result<Response> {
+pub async fn linkup_ws_handler(req: Request, string_store: &impl StringStore) -> Result<Response> {
     let url = match req.url() {
         Ok(url) => url.to_string(),
         Err(_) => return plaintext_error("Bad or missing request url", 400),
@@ -17,7 +17,7 @@ pub async fn linkup_ws_handler(req: Request, sessions: SessionAllocator) -> Resu
     let mut headers = LinkupHeaderMap::from_worker_request(&req);
 
     let (session_name, config) =
-        match sessions.get_request_session(&url, &headers).await {
+        match get_request_session(string_store, &url, &headers).await {
             Ok(result) => result,
             Err(_) => return plaintext_error("Could not find a linkup session for this request. Use a linkup subdomain or context headers like Referer/tracestate", 422),
         };

--- a/worker/src/ws.rs
+++ b/worker/src/ws.rs
@@ -8,7 +8,10 @@ use futures::{
 
 use crate::http_util::plaintext_error;
 
-pub async fn linkup_ws_handler(req: Request, string_store: &impl StringStore) -> Result<Response> {
+pub async fn linkup_ws_handler<'a>(
+    req: Request,
+    allocator: &SessionAllocator<'a>,
+) -> Result<Response> {
     let url = match req.url() {
         Ok(url) => url.to_string(),
         Err(_) => return plaintext_error("Bad or missing request url", 400),
@@ -17,7 +20,7 @@ pub async fn linkup_ws_handler(req: Request, string_store: &impl StringStore) ->
     let mut headers = LinkupHeaderMap::from_worker_request(&req);
 
     let (session_name, config) =
-        match get_request_session(string_store, &url, &headers).await {
+        match allocator.get_request_session(&url, &headers).await {
             Ok(result) => result,
             Err(_) => return plaintext_error("Could not find a linkup session for this request. Use a linkup subdomain or context headers like Referer/tracestate", 422),
         };

--- a/worker/src/ws.rs
+++ b/worker/src/ws.rs
@@ -10,7 +10,7 @@ use crate::http_util::plaintext_error;
 
 pub async fn linkup_ws_handler<'a>(
     req: Request,
-    allocator: &SessionAllocator<'a>,
+    sessions: &'a SessionAllocator<'a>,
 ) -> Result<Response> {
     let url = match req.url() {
         Ok(url) => url.to_string(),
@@ -20,7 +20,7 @@ pub async fn linkup_ws_handler<'a>(
     let mut headers = LinkupHeaderMap::from_worker_request(&req);
 
     let (session_name, config) =
-        match allocator.get_request_session(&url, &headers).await {
+        match sessions.get_request_session(&url, &headers).await {
             Ok(result) => result,
             Err(_) => return plaintext_error("Could not find a linkup session for this request. Use a linkup subdomain or context headers like Referer/tracestate", 422),
         };


### PR DESCRIPTION
### Description
Previously the `SessionAllocator` was designed to have an `Arc<dyn StringStore>`, which caused a [Clippy issue regarding internal of Arc not being Send or Sync](https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync).
For the use case of `SessionAllocator`, it doesn't need to have an internal `Arc` to the `StringStore`, a simple reference seems to be enough.