### PR TITLE
chore: remove unused name generation code

### DIFF
--- a/linkup/src/lib.rs
+++ b/linkup/src/lib.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 
 pub use headers::{HeaderMap, HeaderName};
 pub use memory_session_store::*;
-pub use name_gen::{new_session_name, random_animal, random_six_char};
+pub use name_gen::{random_animal, random_six_char};
 pub use session::*;
 pub use session_allocator::*;
 

--- a/linkup/src/name_gen.rs
+++ b/linkup/src/name_gen.rs
@@ -1,52 +1,6 @@
 use rand::distributions::Alphanumeric;
 use rand::Rng;
 
-use crate::NameKind;
-
-pub fn new_session_name(
-    name_kind: NameKind,
-    desired_name: Option<String>,
-    exists: &dyn Fn(String) -> bool,
-) -> String {
-    let mut key = String::new();
-
-    if let Some(name) = desired_name {
-        if !exists(name.clone()) {
-            key = name;
-        }
-    }
-
-    if key.is_empty() {
-        let mut tried_animal_key = false;
-        loop {
-            let generated_key = if !tried_animal_key && name_kind == NameKind::Animal {
-                tried_animal_key = true;
-                generate_unique_animal_key(20, &exists)
-            } else {
-                random_six_char()
-            };
-
-            if !exists(generated_key.clone()) {
-                key = generated_key;
-                break;
-            }
-        }
-    }
-
-    key
-}
-
-fn generate_unique_animal_key(max_attempts: usize, exists: &dyn Fn(String) -> bool) -> String {
-    for _ in 0..max_attempts {
-        let generated_key = random_animal();
-        if !exists(generated_key.clone()) {
-            return generated_key;
-        }
-    }
-    // Fallback to SixChar logic
-    random_six_char()
-}
-
 pub fn random_animal() -> String {
     let adjective_index = rand::thread_rng().gen_range(0..SHORT_ADJECTIVES.len());
     let animal_index = rand::thread_rng().gen_range(0..ANIMALS.len());


### PR DESCRIPTION
### Description
Remove code for generating a new session name and for generating a unique animal key from inside `name_gen.rs`. It seems like this code now [resides on the `SessionAllocator`](https://github.com/mentimeter/linkup/blob/5a8458adf3b0a3814084fb52ad284a0600e518b8/linkup/src/session_allocator.rs#L115-L159) and that this one is not used anywhere else.