### PR TITLE
fix: add reqwest feature to worker

### DIFF
--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-linkup = { path = "../linkup", features = ["worker"]}
+linkup = { path = "../linkup", features = ["worker", "reqwest"]}
 worker = "0.0.18"
 reqwest = "0.11.22"
 http = "0.2.9"


### PR DESCRIPTION
### Description
Worker also needs access to the `Reqwest` header into `LinkupHeaderMap`, so adding its `Cargo.toml`