### PR TITLE
refactor: move config to cli arguments instead of command

### DIFF
--- a/linkup-cli/src/start.rs
+++ b/linkup-cli/src/start.rs
@@ -97,7 +97,7 @@ fn set_service_env(directory: String, config_path: String) -> Result<(), CliErro
 
     let service_path = PathBuf::from(config_dir).join(&directory);
 
-    let dev_env_files_result = fs::read_dir(&service_path);
+    let dev_env_files_result = fs::read_dir(service_path);
     let dev_env_files: Vec<_> = match dev_env_files_result {
         Ok(entries) => entries
             .filter_map(Result::ok)

--- a/linkup-cli/src/stop.rs
+++ b/linkup-cli/src/stop.rs
@@ -88,7 +88,7 @@ fn remove_service_env(directory: String, config_path: String) -> Result<(), CliE
 
     let service_path = PathBuf::from(config_dir).join(&directory);
 
-    let env_files_result = fs::read_dir(&service_path);
+    let env_files_result = fs::read_dir(service_path);
     let env_files: Vec<_> = match env_files_result {
         Ok(entries) => entries
             .filter_map(Result::ok)


### PR DESCRIPTION
Config is always optional for the commands that use it, so instead of repeating it on all commands, we can move it to the cli arguments so that any command that would like to use this option, could do so.