### PR TITLE
Do not follow redirects on local linkup server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "linkup-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "actix-web",
  "clap",

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkup-cli"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 
 [[bin]]

--- a/linkup-cli/src/local_server.rs
+++ b/linkup-cli/src/local_server.rs
@@ -89,7 +89,7 @@ async fn linkup_ws_request_handler(
     let extra_headers = get_additional_headers(&url, &headers, &session_name, &target_service);
 
     // Proxy the request using the destination_url and the merged headers
-    let client = reqwest::Client::new();
+    let client = no_redirect_client();
     headers.extend(&extra_headers);
     headers.remove(LinkupHeaderName::Host);
 
@@ -193,7 +193,8 @@ async fn linkup_request_handler(
     let extra_headers = get_additional_headers(&url, &headers, &session_name, &target_service);
 
     // Proxy the request using the destination_url and the merged headers
-    let client = reqwest::Client::new();
+    let client = no_redirect_client();
+
     headers.extend(&extra_headers);
     headers.remove(LinkupHeaderName::Host);
 
@@ -248,6 +249,13 @@ async fn convert_reqwest_response(
 
 async fn always_ok() -> impl Responder {
     HttpResponse::Ok().finish()
+}
+
+fn no_redirect_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap()
 }
 
 #[actix_web::main]


### PR DESCRIPTION
This does not make it work when using a cloudflare worker / tunnel. 

The wasm client of reqwest does not support their "redirect policies" yet:

https://github.com/seanmonstar/reqwest/blob/master/src/wasm/client.rs