### PR TITLE
refactor: remove dependency on async-trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,6 @@ name = "linkup"
 version = "0.1.0"
 dependencies = [
  "actix-web",
- "async-trait",
  "getrandom",
  "hex",
  "rand",

--- a/linkup/Cargo.toml
+++ b/linkup/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1.68"
 getrandom = { version = "0.2.8", features = ["js"] }
 hex = "0.4"
 rand = "0.8"

--- a/linkup/src/lib.rs
+++ b/linkup/src/lib.rs
@@ -4,7 +4,8 @@ mod name_gen;
 mod session;
 mod session_allocator;
 
-use async_trait::async_trait;
+use std::future::Future;
+
 use rand::Rng;
 use thiserror::Error;
 
@@ -28,11 +29,13 @@ pub enum SessionError {
     ConfigErr(String),
 }
 
-#[async_trait(?Send)]
+// Since this trait is theoretically public (even though, the idea is for it to be used by the other modules within
+// this workspace), we should return `impl Future` instead of having `async fn` so that we can add and ensure
+// any desired bounds.
 pub trait StringStore {
-    async fn get(&self, key: String) -> Result<Option<String>, SessionError>;
-    async fn exists(&self, key: String) -> Result<bool, SessionError>;
-    async fn put(&self, key: String, value: String) -> Result<(), SessionError>;
+    fn get(&self, key: String) -> impl Future<Output = Result<Option<String>, SessionError>>;
+    fn exists(&self, key: String) -> impl Future<Output = Result<bool, SessionError>>;
+    fn put(&self, key: String, value: String) -> impl Future<Output = Result<(), SessionError>>;
 }
 
 #[derive(PartialEq)]

--- a/linkup/src/memory_session_store.rs
+++ b/linkup/src/memory_session_store.rs
@@ -1,7 +1,5 @@
 use std::{collections::HashMap, sync::RwLock};
 
-use async_trait::async_trait;
-
 use crate::{SessionError, StringStore};
 
 pub struct MemoryStringStore {
@@ -22,7 +20,6 @@ impl Default for MemoryStringStore {
     }
 }
 
-#[async_trait(?Send)]
 impl StringStore for MemoryStringStore {
     async fn get(&self, key: String) -> Result<Option<String>, SessionError> {
         match self.store.read() {

--- a/linkup/src/session_allocator.rs
+++ b/linkup/src/session_allocator.rs
@@ -4,12 +4,12 @@ use crate::{
     StringStore,
 };
 
-pub struct SessionAllocator<'a> {
-    store: &'a dyn StringStore,
+pub struct SessionAllocator<'a, S: StringStore> {
+    store: &'a S,
 }
 
-impl<'a> SessionAllocator<'a> {
-    pub fn new(store: &'a dyn StringStore) -> Self {
+impl<'a, S: StringStore> SessionAllocator<'a, S> {
+    pub fn new(store: &'a S) -> Self {
         Self { store }
     }
 

--- a/worker/src/kv_store.rs
+++ b/worker/src/kv_store.rs
@@ -1,5 +1,5 @@
 use linkup::{SessionError, StringStore};
-use worker::{async_trait::async_trait, kv::KvStore};
+use worker::kv::KvStore;
 
 pub struct CfWorkerStringStore {
     kv: KvStore,
@@ -11,7 +11,6 @@ impl CfWorkerStringStore {
     }
 }
 
-#[async_trait(?Send)]
 impl StringStore for CfWorkerStringStore {
     async fn get(&self, key: String) -> Result<Option<String>, SessionError> {
         match self.kv.get(key.as_str()).text().await {

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -10,9 +10,9 @@ mod kv_store;
 mod utils;
 mod ws;
 
-async fn linkup_session_handler<'a>(
+async fn linkup_session_handler<'a, S: StringStore>(
     mut req: Request,
-    sessions: &'a SessionAllocator<'a>,
+    sessions: &'a SessionAllocator<'a, S>,
 ) -> Result<Response> {
     let body_bytes = match req.bytes().await {
         Ok(bytes) => bytes,
@@ -39,9 +39,9 @@ async fn linkup_session_handler<'a>(
     }
 }
 
-async fn linkup_preview_handler<'a>(
+async fn linkup_preview_handler<'a, S: StringStore>(
     mut req: Request,
-    sessions: &'a SessionAllocator<'a>,
+    sessions: &'a SessionAllocator<'a, S>,
 ) -> Result<Response> {
     let body_bytes = match req.bytes().await {
         Ok(bytes) => bytes,
@@ -110,9 +110,9 @@ async fn set_cached_req(
     Ok(resp)
 }
 
-async fn linkup_request_handler<'a>(
+async fn linkup_request_handler<'a, S: StringStore>(
     mut req: Request,
-    sessions: &'a SessionAllocator<'a>,
+    sessions: &'a SessionAllocator<'a, S>,
 ) -> Result<Response> {
     let url = match req.url() {
         Ok(url) => url.to_string(),

--- a/worker/src/ws.rs
+++ b/worker/src/ws.rs
@@ -8,9 +8,9 @@ use futures::{
 
 use crate::http_util::plaintext_error;
 
-pub async fn linkup_ws_handler<'a>(
+pub async fn linkup_ws_handler<'a, S: StringStore>(
     req: Request,
-    sessions: &'a SessionAllocator<'a>,
+    sessions: &'a SessionAllocator<'a, S>,
 ) -> Result<Response> {
     let url = match req.url() {
         Ok(url) => url.to_string(),


### PR DESCRIPTION
### Description
With the release of [Rust 1.75](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html#async-fn-and-return-position-impl-trait-in-traits), the first round of stabilization of async in traits is out! This does come with its own [set of caveats](https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html#where-the-gaps-lie). But those seem to be mostly for public traits and issues with bounds. The trait that we use it is, theoretically, public. But we intend it to be used by the other modules within the workspace, so it seems like it might be fine to move from the async-trait.

It might be good to test on the worker scenario, since there might be something there that I'm missing, but it seems by the tests and checks that is all working.