### PR TITLE
Use all domains in caddy config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "linkup-cli"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "actix-web",
  "clap",

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkup-cli"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 
 [[bin]]

--- a/linkup-cli/src/local_config.rs
+++ b/linkup-cli/src/local_config.rs
@@ -113,6 +113,12 @@ impl YamlLocalConfig {
             .collect::<Vec<String>>()
     }
 
+    pub fn domains(&self) -> Vec<String> {
+        self.domains
+            .iter()
+            .collect::<Vec<String>>()
+    }
+
     pub fn create_preview_request(&self, services: &[(String, String)]) -> CreatePreviewRequest {
         let services = self
             .services

--- a/linkup-cli/src/local_config.rs
+++ b/linkup-cli/src/local_config.rs
@@ -116,6 +116,7 @@ impl YamlLocalConfig {
     pub fn domains(&self) -> Vec<String> {
         self.domains
             .iter()
+            .map(|storable_domain| storable_domain.domain.clone())
             .collect::<Vec<String>>()
     }
 

--- a/linkup-cli/src/services/caddy.rs
+++ b/linkup-cli/src/services/caddy.rs
@@ -21,7 +21,7 @@ pub fn start(local_config: &YamlLocalConfig) -> Result<()> {
     }
 
     let domains: Vec<String> = local_config
-        .top_level_domains()
+        .domains()
         .iter()
         .map(|domain| format!("{domain}, *.{domain}"))
         .collect();


### PR DESCRIPTION
supports *.api.mentimeter.dev for example