### PR TITLE
Unfold worker response cookies

### DIFF
--- a/linkup/src/lib.rs
+++ b/linkup/src/lib.rs
@@ -15,6 +15,9 @@ pub use name_gen::{random_animal, random_six_char};
 pub use session::*;
 pub use session_allocator::*;
 
+#[cfg(feature = "worker")]
+pub use headers::unpack_cookie_header;
+
 use url::Url;
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
- The underlying wasm/rust bindings seem to be folding cookies. getSetCookie is not a valid web_sys function yet..
- This is not-exhaustive cookie unfolding. Quotes, for example, are not yet supported