### PR TITLE
Only route local dns to active sessions

### DIFF
--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -117,6 +117,8 @@ pub enum CliError {
     LocalDNSUninstall(String),
     #[error("failed to write file: {0}")]
     WriteFile(String),
+    #[error("failed to reboot dnsmasq: {0}")]
+    RebootDNSMasq(String),
 }
 
 #[derive(Parser)]

--- a/linkup-cli/src/services/dnsmasq.rs
+++ b/linkup-cli/src/services/dnsmasq.rs
@@ -1,10 +1,10 @@
 use std::{
     fs,
-    path::Path,
     process::{Command, Stdio},
 };
 
-use nix::sys::signal::Signal;
+use nix::sys::signal::{kill, Signal};
+use nix::unistd::Pid;
 
 use crate::{linkup_dir_path, linkup_file_path, stop::stop_pid_file, CliError, Result};
 
@@ -14,18 +14,7 @@ const LOG_FILE: &str = "dnsmasq-log";
 const PID_FILE: &str = "dnsmasq-pid";
 
 pub fn start() -> Result<()> {
-    let conf_file_path = linkup_file_path(CONF_FILE);
-    let logfile_path = linkup_file_path(LOG_FILE);
-    let pidfile_path = linkup_file_path(PID_FILE);
-
-    if fs::write(&logfile_path, "").is_err() {
-        return Err(CliError::WriteFile(format!(
-            "Failed to write dnsmasq log file at {}",
-            logfile_path.display()
-        )));
-    }
-
-    write_conf_file(&conf_file_path, &logfile_path, &pidfile_path)?;
+    let conf_file_path = write_dnsmaq_conf(None)?;
 
     Command::new("dnsmasq")
         .current_dir(linkup_dir_path())
@@ -45,14 +34,30 @@ pub fn stop() {
     let _ = stop_pid_file(&linkup_file_path(PID_FILE), Signal::SIGTERM);
 }
 
-fn write_conf_file(conf_file_path: &Path, logfile_path: &Path, pidfile_path: &Path) -> Result<()> {
+pub fn write_dnsmaq_conf(local_domains: Option<Vec<String>>) -> Result<String> {
+    let conf_file_path = linkup_file_path(CONF_FILE);
+    let logfile_path = linkup_file_path(LOG_FILE);
+    let pidfile_path = linkup_file_path(PID_FILE);
+    let mut local_domains_template = String::new();
+    if let Some(local_domains) = local_domains {
+        local_domains_template = local_domains
+            .iter()
+            .map(|d| format!("address=/{}/127.0.0.1\naddress=/{}/::1\n", d, d))
+            .collect()
+    }
+
     let dnsmasq_template = format!(
         "
-            address=/#/127.0.0.1
-            port={}
-            log-facility={}
-            pid-file={}
+# Set of domains that should be routed locally
+{}
+
+# Other dnsmasq config options
+server=1.1.1.1
+port={}
+log-facility={}
+pid-file={}
         ",
+        local_domains_template,
         PORT,
         logfile_path.display(),
         pidfile_path.display(),
@@ -61,9 +66,35 @@ fn write_conf_file(conf_file_path: &Path, logfile_path: &Path, pidfile_path: &Pa
     if fs::write(conf_file_path, dnsmasq_template).is_err() {
         return Err(CliError::WriteFile(format!(
             "Failed to write dnsmasq config at {}",
-            conf_file_path.display()
+            linkup_file_path(CONF_FILE).display()
         )));
     }
+
+    Ok(linkup_file_path(CONF_FILE)
+        .to_str()
+        .expect("const path known to be valid")
+        .to_string())
+}
+
+pub fn reload_dnsmasq_conf() -> Result<()> {
+    let pidfile_path = linkup_file_path(PID_FILE);
+    let pid_str = fs::read_to_string(pidfile_path).map_err(|e| {
+        CliError::RebootDNSMasq(format!(
+            "Failed to read PID file at {}: {}",
+            linkup_file_path(PID_FILE).display(),
+            e
+        ))
+    })?;
+
+    // Parse the PID from the file content
+    let pid = pid_str
+        .trim()
+        .parse::<i32>()
+        .map_err(|e| CliError::RebootDNSMasq(format!("Invalid PID value: {}", e)))?;
+
+    // Send SIGHUP signal to the dnsmasq process
+    kill(Pid::from_raw(pid), Signal::SIGHUP)
+        .map_err(|e| CliError::RebootDNSMasq(format!("Failed to send SIGHUP to dnsmasq: {}", e)))?;
 
     Ok(())
 }


### PR DESCRIPTION
- Users may want to view other linkup sessions, or preview environments.
- With local-dns enabled, all these are routed to the local server where the session does not exist
- Default dnsmasq to route to the public internet, but add special rules for the active local session instead