### PR TITLE
Use deterministic 6 char names for preview envs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -1033,6 +1033,7 @@ dependencies = [
  "reqwest 0.11.22",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "tokio",
  "unicase",
@@ -1816,6 +1817,17 @@ name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/linkup/Cargo.toml
+++ b/linkup/Cargo.toml
@@ -10,6 +10,7 @@ rand = "0.8"
 regex = "1.7.1"
 serde = "1.0.156"
 serde_json = "1.0.96"
+sha2 = "0.10.8"
 thiserror = "1.0.39"
 unicase = "2.7"
 url = { version = "2.3.1", features = ["serde"] }

--- a/linkup/src/name_gen.rs
+++ b/linkup/src/name_gen.rs
@@ -1,5 +1,6 @@
 use rand::distributions::Alphanumeric;
 use rand::Rng;
+use sha2::{Digest, Sha256};
 
 pub fn random_animal() -> String {
     let adjective_index = rand::thread_rng().gen_range(0..SHORT_ADJECTIVES.len());
@@ -9,6 +10,18 @@ pub fn random_animal() -> String {
         "{}-{}",
         SHORT_ADJECTIVES[adjective_index], ANIMALS[animal_index]
     )
+}
+
+pub fn deterministic_six_char_hash(input: &str) -> String {
+    let mut hasher = Sha256::new();
+
+    hasher.update(input);
+
+    let result = hasher.finalize();
+    let hex_string = hex::encode(result);
+
+    // Truncate the hexadecimal string to 6 characters
+    hex_string[..6].to_string()
 }
 
 pub fn random_six_char() -> String {


### PR DESCRIPTION
- This allows preview environments to keep the same url over multiple underlying deployments, as long as the linkup config doesn't change