### PR TITLE
Enable redis as a caddy shared storage module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "linkup-cli"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "actix-web",
  "clap",

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkup-cli"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2021"
 
 [[bin]]

--- a/linkup-cli/src/local_dns.rs
+++ b/linkup-cli/src/local_dns.rs
@@ -35,6 +35,7 @@ pub fn install(config_arg: &Option<String>) -> Result<()> {
     ensure_resolver_dir()?;
     install_resolvers(&input_config.top_level_domains())?;
     services::caddy::install_cloudflare_package()?;
+    services::caddy::install_redis_package()?;
 
     if fs::write(linkup_file_path(LINKUP_LOCALDNS_INSTALL), "").is_err() {
         return Err(CliError::LocalDNSInstall(format!(

--- a/linkup-cli/src/services/caddy.rs
+++ b/linkup-cli/src/services/caddy.rs
@@ -63,7 +63,44 @@ pub fn install_cloudflare_package() -> Result<()> {
     Ok(())
 }
 
+pub fn install_redis_package() -> Result<()> {
+    Command::new("caddy")
+        .args(["add-package", "github.com/pberkel/caddy-storage-redis"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|err| CliError::StartCaddy(err.to_string()))?;
+
+    Ok(())
+}
+
 fn write_caddyfile(domains: &[String]) -> Result<()> {
+    let mut redis_storage = String::new();
+
+    if let Ok(redis_url) = std::env::var("LINKUP_CERT_STORAGE_REDIS_URL") {
+        // This is worth doing to avoid confusion while the redis storage module is new
+        check_redis_installed()?;
+
+        let url = url::Url::parse(&redis_url)
+            .map_err(|_| CliError::StartCaddy(format!("Invalid REDIS_URL: {}", redis_url)))?;
+        redis_storage = format!(
+            "
+            storage redis {{
+                host           {}
+                port           {}
+                username       \"{}\"
+                password       \"{}\"
+                key_prefix     \"caddy\"
+                compression    true
+            }}
+            ",
+            url.host().unwrap(),
+            url.port().unwrap_or(6379),
+            url.username(),
+            url.password().unwrap(),
+        );
+    }
+
     let caddy_template = format!(
         "
         {{
@@ -72,6 +109,7 @@ fn write_caddyfile(domains: &[String]) -> Result<()> {
             log {{
                 output file {}
             }}
+            {}
         }}
 
         {} {{
@@ -82,6 +120,7 @@ fn write_caddyfile(domains: &[String]) -> Result<()> {
         }}
         ",
         linkup_file_path(LOG_FILE).display(),
+        redis_storage,
         domains.join(", "),
         LINKUP_LOCALSERVER_PORT,
         LINKUP_CF_TLS_API_ENV_VAR,
@@ -93,6 +132,26 @@ fn write_caddyfile(domains: &[String]) -> Result<()> {
             "Failed to write Caddyfile at {}",
             caddyfile_path.display(),
         )));
+    }
+
+    Ok(())
+}
+
+fn check_redis_installed() -> Result<()> {
+    let output = Command::new("caddy")
+        .arg("list-modules")
+        .output()
+        .map_err(|err| CliError::StartCaddy(err.to_string()))?;
+
+    let output_str = String::from_utf8(output.stdout).map_err(|_| {
+        CliError::StartCaddy("Failed to parse caddy list-modules output".to_string())
+    })?;
+
+    if !output_str.contains("redis") {
+        println!("Redis shared storage is a new feature! You need to uninstall and reinstall local-dns to use it.");
+        println!("Run `linkup local-dns uninstall && linkup local-dns install`");
+
+        return Err(CliError::StartCaddy("Redis module not found".to_string()));
     }
 
     Ok(())


### PR DESCRIPTION
- Lets engineers share letsencrypt storage
- Reduces the amount of calls we make to letsencrypt
- Reduces the amount of rate limits we hit