### PR TITLE
doc: add link to linkup docs in help command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "linkup-cli"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "actix-web",
  "clap",

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkup-cli"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2021"
 
 [[bin]]

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -131,7 +131,7 @@ pub enum CheckErr {
 #[derive(Parser)]
 #[command(
     name = "linkup",
-    about = "Connect remote and local dev/preview environments",
+    about = "Connect remote and local dev/preview environments\n\nIf you need help running linkup, start here:\nhttps://github.com/mentimeter/linkup/blob/main/docs/using-linkup.md",
     version = env!("CARGO_PKG_VERSION"),
 )]
 struct Cli {


### PR DESCRIPTION
https://linear.app/mentimeter/issue/DO-1380/add-linkup-docs-links-to-the-help-command