### PR TITLE
feat: random tunnel secret

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "ahash",
- "base64",
+ "base64 0.21.7",
  "bitflags 2.4.2",
  "brotli",
  "bytes",
@@ -324,6 +324,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -1180,6 +1186,7 @@ dependencies = [
 name = "linkup-cli"
 version = "0.2.15"
 dependencies = [
+ "base64 0.22.1",
  "clap",
  "clap_complete",
  "colored",
@@ -1731,7 +1738,7 @@ name = "reqwest"
 version = "0.11.23"
 source = "git+https://github.com/ostenbom/reqwest.git?branch=add-wasm-redirect#a055a9025d579e30225ba4f50c435cebfbf4aacc"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1771,7 +1778,7 @@ version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1880,7 +1887,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -30,3 +30,4 @@ serde_yaml = "0.9"
 thiserror = "1"
 url = { version = "2.5", features = ["serde"] }
 mockall = "0.12.1"
+base64 = "0.22.1"

--- a/linkup-cli/src/file_system.rs
+++ b/linkup-cli/src/file_system.rs
@@ -1,0 +1,31 @@
+use crate::CliError;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+pub trait FileLike: Read + Write {}
+impl FileLike for std::fs::File {}
+
+#[cfg_attr(test, mockall::automock)]
+pub trait FileSystem {
+    fn create_file(&self, path: PathBuf) -> Result<Box<dyn FileLike>, CliError>;
+    fn write_file(&self, file: &mut Box<dyn FileLike>, content: &str) -> Result<(), CliError>;
+    fn file_exists(&self, file_path: &str) -> bool {
+        Path::new(file_path).exists()
+    }
+}
+
+pub struct RealFileSystem;
+
+impl FileSystem for RealFileSystem {
+    fn create_file(&self, path: PathBuf) -> Result<Box<dyn FileLike>, CliError> {
+        let file = File::create(path).map_err(|err| CliError::StatusErr(err.to_string()))?;
+        Ok(Box::new(file))
+    }
+
+    fn write_file(&self, file: &mut Box<dyn FileLike>, content: &str) -> Result<(), CliError> {
+        file.write_all(content.as_bytes())
+            .map_err(|err| CliError::StatusErr(err.to_string()))?;
+        Ok(())
+    }
+}

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 mod background_booting;
 mod completion;
 mod env_files;
+mod file_system;
 mod local_config;
 mod local_dns;
 mod preview;

--- a/linkup-cli/src/start.rs
+++ b/linkup-cli/src/start.rs
@@ -6,8 +6,10 @@ use std::{
 use crate::{
     background_booting::boot_background_services,
     env_files::write_to_env_file,
+    file_system::{FileSystem, RealFileSystem},
     linkup_file_path,
     local_config::{config_path, config_to_state, get_config},
+    tunnel::{RealTunnelManager, TunnelManager},
     LINKUP_LOCALDNS_INSTALL,
 };
 use crate::{
@@ -16,43 +18,53 @@ use crate::{
     CliError,
 };
 
-use crate::tunnel::{create_dns_record, create_tunnel, get_tunnel_id};
-
-fn file_exists(file_path: &str) -> bool {
-    Path::new(file_path).exists()
-}
-
 pub fn start(config_arg: &Option<String>, no_tunnel: bool) -> Result<(), CliError> {
-    if env::var("PAID_TUNNELS").is_ok() {
-        start_paid_tunnel()?;
+    if use_paid_tunnels() {
+        start_paid_tunnel(&RealTunnelManager, &RealFileSystem, "happy-lion")?;
     } else {
         start_free_tunnel(config_arg, no_tunnel)?;
     }
     Ok(())
 }
 
-fn start_paid_tunnel() -> Result<(), CliError> {
-    println!("Starting paid tunnel");
-    let tunnel_name = "happy-lion".to_string();
-    let tunnel_id = match get_tunnel_id(&tunnel_name) {
+fn use_paid_tunnels() -> bool {
+    env::var("LINKUP_CLOUDFLARE_ACCOUNT_ID").is_ok()
+        && env::var("LINKUP_CLOUDFLARE_ZONE_ID").is_ok()
+        && env::var("LINKUP_CF_API_TOKEN").is_ok()
+}
+
+fn start_paid_tunnel(
+    manager: &dyn TunnelManager,
+    fs: &dyn FileSystem,
+    session_name: &str,
+) -> Result<(), CliError> {
+    println!("Starting paid tunnel with session name: {}", session_name);
+    let tunnel_name = session_name.to_string();
+    let tunnel_id = match manager.get_tunnel_id(&tunnel_name) {
         Ok(Some(id)) => id,
         Ok(None) => "".to_string(),
         Err(e) => return Err(e),
     };
 
     // If there exists a /$ENV_HOME/.cloudflared/<Tunnel-UUID>.json file, skip creating a tunnel
-    let file_path = format!(
-        "{}/.cloudflared/{}.json",
-        env::var("HOME").expect("HOME is not set"),
-        tunnel_id
-    );
-    if file_exists(&file_path) {
-        println!("File exists: {}", file_path);
+    if tunnel_id.is_empty() {
+        println!("Tunnel ID is empty");
     } else {
-        println!("File does not exist: {}", file_path);
-        let tunnel_id = create_tunnel(&tunnel_name)?;
-        create_dns_record(&tunnel_id, &tunnel_name)?;
+        println!("Tunnel ID: {}", tunnel_id);
+        let file_path = format!(
+            "{}/.cloudflared/{}.json",
+            env::var("HOME").expect("HOME is not set"),
+            tunnel_id
+        );
+        if fs.file_exists(&file_path) {
+            println!("File exists: {}", file_path);
+            return Ok(());
+        }
     }
+
+    println!("Creating tunnel");
+    let tunnel_id = manager.create_tunnel(&tunnel_name)?;
+    manager.create_dns_record(&tunnel_id, &tunnel_name)?;
     Ok(())
 }
 
@@ -150,4 +162,41 @@ fn check_local_not_started() -> Result<(), CliError> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{file_system::MockFileSystem, tunnel::MockTunnelManager};
+
+    use super::*;
+
+    #[test]
+    fn test_start_paid_tunnel_tunnel_exists() {
+        let mut mock_manager = MockTunnelManager::new();
+        let mut mock_fs = MockFileSystem::new();
+        mock_manager
+            .expect_get_tunnel_id()
+            .returning(|_| Ok(Some("test_tunnel_id".to_string())));
+        mock_fs.expect_file_exists().returning(|_| true);
+        mock_manager.expect_create_tunnel().never();
+        mock_manager.expect_create_dns_record().never();
+        let _result = start_paid_tunnel(&mock_manager, &mock_fs, "test_session");
+    }
+
+    #[test]
+    fn test_start_paid_tunnel_no_tunnel_exists() {
+        let mut mock_manager = MockTunnelManager::new();
+        let mut mock_fs = MockFileSystem::new();
+        mock_manager.expect_get_tunnel_id().returning(|_| Ok(None));
+        mock_fs.expect_file_exists().never();
+        mock_manager
+            .expect_create_tunnel()
+            .times(1)
+            .returning(|_| Ok("tunnel-id".to_string()));
+        mock_manager
+            .expect_create_dns_record()
+            .times(1)
+            .returning(|_, _| Ok(()));
+        let _result = start_paid_tunnel(&mock_manager, &mock_fs, "test_session");
+    }
 }

--- a/linkup-cli/src/tunnel.rs
+++ b/linkup-cli/src/tunnel.rs
@@ -1,15 +1,17 @@
 use std::{
     env,
-    fs::{self, File},
-    io::{Read, Write},
-    path::{Path, PathBuf},
+    fs::{self},
+    path::Path,
 };
 
-use mockall::automock;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 
+use crate::file_system::{FileLike, FileSystem, RealFileSystem};
 use crate::CliError;
 use serde::{Deserialize, Serialize};
+
+use base64::prelude::*;
+use rand::Rng;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct GetTunnelApiResponse {
@@ -106,55 +108,98 @@ fn send_request<T: for<'de> serde::Deserialize<'de>>(
     }
 }
 
-pub fn get_tunnel_id(tunnel_name: &str) -> Result<Option<String>, CliError> {
-    let account_id = env::var("LINKUP_CLOUDFLARE_ACCOUNT_ID")
-        .map_err(|err| CliError::BadConfig(err.to_string()))?;
-    let url = format!(
-        "https://api.cloudflare.com/client/v4/accounts/{}/cfd_tunnel",
-        account_id
-    );
-    let (client, headers) = prepare_client_and_headers()?;
-    let query_url = format!("{}?name=tunnel-{}", url, tunnel_name);
+#[cfg_attr(test, mockall::automock)]
+pub trait TunnelManager {
+    fn get_tunnel_id(&self, tunnel_name: &str) -> Result<Option<String>, CliError>;
+    fn create_tunnel(&self, tunnel_name: &str) -> Result<String, CliError>;
+    fn create_dns_record(&self, tunnel_id: &str, tunnel_name: &str) -> Result<(), CliError>;
+}
 
-    let parsed: GetTunnelApiResponse = send_request(&client, &query_url, headers, None, "GET")?;
-    if parsed.result.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(parsed.result[0].id.clone()))
+pub struct RealTunnelManager;
+
+impl TunnelManager for RealTunnelManager {
+    fn get_tunnel_id(&self, tunnel_name: &str) -> Result<Option<String>, CliError> {
+        let account_id = env::var("LINKUP_CLOUDFLARE_ACCOUNT_ID")
+            .map_err(|err| CliError::BadConfig(err.to_string()))?;
+        let url = format!(
+            "https://api.cloudflare.com/client/v4/accounts/{}/cfd_tunnel",
+            account_id
+        );
+        let (client, headers) = prepare_client_and_headers()?;
+        let query_url = format!("{}?name=tunnel-{}", url, tunnel_name);
+
+        let parsed: GetTunnelApiResponse = send_request(&client, &query_url, headers, None, "GET")?;
+        if parsed.result.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(parsed.result[0].id.clone()))
+        }
+    }
+
+    fn create_tunnel(&self, tunnel_name: &str) -> Result<String, CliError> {
+        let tunnel_secret = generate_tunnel_secret();
+        let account_id = env::var("LINKUP_CLOUDFLARE_ACCOUNT_ID")
+            .map_err(|err| CliError::BadConfig(err.to_string()))?;
+        let url = format!(
+            "https://api.cloudflare.com/client/v4/accounts/{}/cfd_tunnel",
+            account_id,
+        );
+        let (client, headers) = prepare_client_and_headers()?;
+        let body = serde_json::to_string(&CreateTunnelRequest {
+            name: format!("tunnel-{}", tunnel_name),
+            tunnel_secret: tunnel_secret.clone(),
+        })
+        .map_err(|err| CliError::StatusErr(err.to_string()))?;
+
+        let parsed: CreateTunnelResponse =
+            send_request(&client, &url, headers, Some(body), "POST")?;
+        save_tunnel_credentials(&RealFileSystem, &parsed.result.id, &tunnel_secret)
+            .map_err(|err| CliError::StatusErr(err.to_string()))?;
+        create_config_yml(&RealFileSystem, &parsed.result.id)
+            .map_err(|err| CliError::StatusErr(err.to_string()))?;
+
+        Ok(parsed.result.id)
+    }
+
+    fn create_dns_record(&self, tunnel_id: &str, tunnel_name: &str) -> Result<(), CliError> {
+        //let zone_id = env::var("LINKUP_CLOUDFLARE_ZONE_ID").map_err(|err| CliError::BadConfig(err.to_string()) )?;
+        let zone_id = "ZONE_ID";
+        let url = format!(
+            "https://api.cloudflare.com/client/v4/zones/{}/dns_records",
+            zone_id
+        );
+        let (client, headers) = prepare_client_and_headers()?;
+        let body = serde_json::to_string(&CreateDNSRecordRequest {
+            name: format!("tunnel-{}", tunnel_name),
+            content: format!("{}.cfargotunnel.com", tunnel_id),
+            r#type: "CNAME".to_string(),
+            proxied: true,
+        })
+        .map_err(|err| CliError::StatusErr(err.to_string()))?;
+
+        println!("{}", body);
+
+        send_request(&client, &url, headers, Some(body), "POST")
     }
 }
 
-pub fn create_tunnel(tunnel_name: &str) -> Result<String, CliError> {
-    let tunnel_secret = "AQIDBAUGBwgBAgMEBQYHCAECAwQFBgcIAQIDBAUGBwg=".to_string(); // This is a hardcoded secret, it should be generated
-    let account_id = env::var("LINKUP_CLOUDFLARE_ACCOUNT_ID")
-        .map_err(|err| CliError::BadConfig(err.to_string()))?;
-    let url = format!(
-        "https://api.cloudflare.com/client/v4/accounts/{}/cfd_tunnel",
-        account_id,
-    );
-    let (client, headers) = prepare_client_and_headers()?;
-    let body = serde_json::to_string(&CreateTunnelRequest {
-        name: format!("tunnel-{}", tunnel_name),
-        tunnel_secret: tunnel_secret.clone(),
-    })
-    .map_err(|err| CliError::StatusErr(err.to_string()))?;
-
-    let parsed: CreateTunnelResponse = send_request(&client, &url, headers, Some(body), "POST")?;
-    save_tunnel_credentials(&parsed.result.id, &tunnel_secret)
-        .map_err(|err| CliError::StatusErr(err.to_string()))?;
-    create_config_yml(&RealFileSystem, &parsed.result.id)
-        .map_err(|err| CliError::StatusErr(err.to_string()))?;
-
-    Ok(parsed.result.id)
+fn generate_tunnel_secret() -> String {
+    let mut rng = rand::thread_rng();
+    let random_bytes: [u8; 32] = rng.gen();
+    BASE64_STANDARD.encode(random_bytes)
 }
 
-fn save_tunnel_credentials(tunnel_id: &str, tunnel_secret: &str) -> Result<(), CliError> {
+fn save_tunnel_credentials(
+    fs: &dyn FileSystem,
+    tunnel_id: &str,
+    tunnel_secret: &str,
+) -> Result<(), CliError> {
     let account_id = env::var("LINKUP_CLOUDFLARE_ACCOUNT_ID")
         .map_err(|err| CliError::BadConfig(err.to_string()))?;
     let data = serde_json::json!({
         "AccountTag": account_id,
-        "TunnelSecret": tunnel_secret,
         "TunnelID": tunnel_id,
+        "TunnelSecret": tunnel_secret,
     });
 
     // Determine the directory path
@@ -170,8 +215,12 @@ fn save_tunnel_credentials(tunnel_id: &str, tunnel_secret: &str) -> Result<(), C
     let file_path = dir_path.join(format!("{}.json", tunnel_id));
 
     // Create and write to the file
-    let mut file = File::create(file_path).map_err(|err| CliError::StatusErr(err.to_string()))?;
-    write!(file, "{}", data).map_err(|err| CliError::StatusErr(err.to_string()))?;
+    let mut file: Box<dyn FileLike> = fs
+        .create_file(file_path)
+        .map_err(|err| CliError::StatusErr(err.to_string()))?;
+    let data_string = data.to_string();
+    fs.write_file(&mut file, &data_string)
+        .map_err(|err| CliError::StatusErr(err.to_string()))?;
 
     Ok(())
 }
@@ -201,62 +250,19 @@ fn create_config_yml(fs: &dyn FileSystem, tunnel_id: &str) -> Result<(), CliErro
     let mut file: Box<dyn FileLike> = fs
         .create_file(dir_path.join("config.yml"))
         .map_err(|err| CliError::StatusErr(err.to_string()))?;
-    fs.write_file(&mut file, serialized.as_bytes())
+    fs.write_file(&mut file, &serialized)
         .map_err(|err| CliError::StatusErr(err.to_string()))?;
     Ok(())
 }
 
-pub fn create_dns_record(tunnel_id: &str, tunnel_name: &str) -> Result<(), CliError> {
-    //let zone_id = env::var("LINKUP_CLOUDFLARE_ZONE_ID").map_err(|err| CliError::BadConfig(err.to_string()) )?;
-    let zone_id = "ZONE_ID";
-    let url = format!(
-        "https://api.cloudflare.com/client/v4/zones/{}/dns_records",
-        zone_id
-    );
-    let (client, headers) = prepare_client_and_headers()?;
-    let body = serde_json::to_string(&CreateDNSRecordRequest {
-        name: format!("tunnel-{}", tunnel_name),
-        content: format!("{}.cfargotunnel.com", tunnel_id),
-        r#type: "CNAME".to_string(),
-        proxied: true,
-    })
-    .map_err(|err| CliError::StatusErr(err.to_string()))?;
-
-    println!("{}", body);
-
-    send_request(&client, &url, headers, Some(body), "POST")
-}
-
-#[automock]
-trait FileSystem {
-    fn create_file(&self, path: PathBuf) -> Result<Box<dyn FileLike>, CliError>;
-    fn write_file(&self, file: &mut Box<dyn FileLike>, content: &[u8]) -> Result<(), CliError>;
-}
-
-struct RealFileSystem;
-
-impl FileSystem for RealFileSystem {
-    fn create_file(&self, path: PathBuf) -> Result<Box<dyn FileLike>, CliError> {
-        let file = File::create(path).map_err(|err| CliError::StatusErr(err.to_string()))?;
-        Ok(Box::new(file))
-    }
-
-    fn write_file(&self, file: &mut Box<dyn FileLike>, content: &[u8]) -> Result<(), CliError> {
-        file.write_all(content)
-            .map_err(|err| CliError::StatusErr(err.to_string()))?;
-        Ok(())
-    }
-}
-
-pub trait FileLike: Read + Write {}
-impl FileLike for std::fs::File {}
-
 #[cfg(test)]
 mod tests {
-
     use super::*;
+
+    use crate::file_system::MockFileSystem;
+
     use mockall::predicate;
-    use std::io::Result as IoResult;
+    use std::io::{Read, Write, Result as IoResult};
     struct MockFile {
         content: Vec<u8>,
     }
@@ -313,12 +319,45 @@ mod tests {
             .returning(|_| Ok(Box::new(MockFile::new()) as Box<dyn FileLike>));
         file_system_mock
             .expect_write_file()
-            .with(predicate::always(), predicate::eq(content.as_bytes()))
+            .with(predicate::always(), predicate::eq(content))
             .returning(|_, _| Ok(()));
 
         let result = create_config_yml(&file_system_mock, "TUNNEL_ID");
         assert!(result.is_ok());
 
         env::remove_var("HOME")
+    }
+
+    #[test]
+    fn test_save_tunnel_credentials() {
+        env::set_var("HOME", "/tmp/home");
+        env::set_var("LINKUP_CLOUDFLARE_ACCOUNT_ID", "ACCOUNT_ID");
+        let content = "{\"AccountTag\":\"ACCOUNT_ID\",\"TunnelID\":\"TUNNEL_ID\",\"TunnelSecret\":\"AQIDBAUGBwgBAgMEBQYHCAECAwQFBgcIAQIDBAUGBwg=\"}";
+
+        let mut file_system_mock = MockFileSystem::new();
+        file_system_mock
+            .expect_create_file()
+            .withf(|path| path.ends_with("TUNNEL_ID.json"))
+            .returning(|_| Ok(Box::new(MockFile::new()) as Box<dyn FileLike>));
+        file_system_mock
+            .expect_write_file()
+            .with(predicate::always(), predicate::eq(content))
+            .returning(|_, _| Ok(()));
+
+        let result = save_tunnel_credentials(
+            &file_system_mock,
+            "TUNNEL_ID",
+            "AQIDBAUGBwgBAgMEBQYHCAECAwQFBgcIAQIDBAUGBwg=",
+        );
+        assert!(result.is_ok());
+
+        env::remove_var("HOME");
+        env::remove_var("LINKUP_CLOUDFLARE_ACCOUNT_ID");
+    }
+
+    #[test]
+    fn test_generate_tunnel_secret() {
+        let secret = generate_tunnel_secret();
+        assert_eq!(secret.len(), 44);
     }
 }


### PR DESCRIPTION
- random tunnel secret
- test save credentials.
- Send the contents of files in write_files as a string instead of bytes for simpler debugging.