### PR TITLE
Disable cache everything on previews

### DIFF
--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -172,10 +172,6 @@ fn is_cacheable_request(req: &Request, config: &Session) -> bool {
         return false;
     }
 
-    if config.session_token == PREVIEW_SESSION_TOKEN {
-        return true;
-    }
-
     if let Some(routes) = &config.cache_routes {
         let path = req.path();
         if routes.iter().any(|route| route.is_match(&path)) {


### PR DESCRIPTION
- This was incorrectly causing some pages to be cached in previews that shouldn't have
- underlying cf pages servers have their own caches
- use the default "cache allowlist" functionality of linkup instead, which allows for some heroku asset caching