### PR TITLE
Ensure that file system operations are mocked

### DIFF
--- a/linkup-cli/src/file_system.rs
+++ b/linkup-cli/src/file_system.rs
@@ -1,5 +1,5 @@
 use crate::CliError;
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
@@ -10,9 +10,8 @@ impl FileLike for std::fs::File {}
 pub trait FileSystem {
     fn create_file(&self, path: PathBuf) -> Result<Box<dyn FileLike>, CliError>;
     fn write_file(&self, file: &mut Box<dyn FileLike>, content: &str) -> Result<(), CliError>;
-    fn file_exists(&self, file_path: &str) -> bool {
-        Path::new(file_path).exists()
-    }
+    fn file_exists(&self, file_path: &Path) -> bool;
+    fn create_dir_all(&self, path: &Path) -> Result<(), CliError>;
 }
 
 pub struct RealFileSystem;
@@ -27,5 +26,13 @@ impl FileSystem for RealFileSystem {
         file.write_all(content.as_bytes())
             .map_err(|err| CliError::StatusErr(err.to_string()))?;
         Ok(())
+    }
+
+    fn file_exists(&self, file_path: &Path) -> bool {
+        file_path.exists()
+    }
+
+    fn create_dir_all(&self, path: &Path) -> Result<(), CliError> {
+        fs::create_dir_all(path).map_err(|err| CliError::StatusErr(err.to_string()))
     }
 }

--- a/linkup-cli/src/start.rs
+++ b/linkup-cli/src/start.rs
@@ -35,7 +35,7 @@ fn use_paid_tunnels() -> bool {
 
 fn start_paid_tunnel(
     manager: &dyn TunnelManager,
-    fs: &dyn FileSystem,
+    filesys: &dyn FileSystem,
     session_name: &str,
 ) -> Result<(), CliError> {
     println!("Starting paid tunnel with session name: {}", session_name);
@@ -56,7 +56,7 @@ fn start_paid_tunnel(
             env::var("HOME").expect("HOME is not set"),
             tunnel_id
         );
-        if fs.file_exists(&file_path) {
+        if filesys.file_exists(Path::new(&file_path)) {
             println!("File exists: {}", file_path);
             return Ok(());
         }
@@ -172,6 +172,7 @@ mod tests {
 
     #[test]
     fn test_start_paid_tunnel_tunnel_exists() {
+        env::set_var("HOME", "/tmp/home");
         let mut mock_manager = MockTunnelManager::new();
         let mut mock_fs = MockFileSystem::new();
         mock_manager
@@ -181,6 +182,7 @@ mod tests {
         mock_manager.expect_create_tunnel().never();
         mock_manager.expect_create_dns_record().never();
         let _result = start_paid_tunnel(&mock_manager, &mock_fs, "test_session");
+        env::remove_var("HOME");
     }
 
     #[test]


### PR DESCRIPTION
- Test the two main paths for `create_config_yml`, 1) `.cloudflared` directory exists and 2) doesn't exist. 
- Ensure that all "real" file system operations are mocked and don't actually create real files.
- Align some variable naming across files
- Rename the param `fs` -> `filesys` to avoid confusion with `std::fs`