### PR TITLE
Add tests to start.rs

### DIFF
--- a/linkup-cli/src/local_config.rs
+++ b/linkup-cli/src/local_config.rs
@@ -12,7 +12,7 @@ use linkup::{CreatePreviewRequest, StorableDomain, StorableRewrite, StorableServ
 
 use crate::{linkup_file_path, CliError, LINKUP_CONFIG_ENV, LINKUP_STATE_FILE};
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct LocalState {
     pub linkup: LinkupState,
     pub domains: Vec<StorableDomain>,
@@ -83,7 +83,7 @@ impl LocalState {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct LinkupState {
     pub session_name: String,
     pub session_token: String,
@@ -93,7 +93,7 @@ pub struct LinkupState {
     pub cache_routes: Option<Vec<String>>,
 }
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct LocalService {
     pub name: String,
     pub remote: Url,

--- a/linkup/src/session.rs
+++ b/linkup/src/session.rs
@@ -73,20 +73,20 @@ pub struct StorableService {
     pub rewrites: Option<Vec<StorableRewrite>>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct StorableRewrite {
     pub source: String,
     pub target: String,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct StorableDomain {
     pub domain: String,
     pub default_service: String,
     pub routes: Option<Vec<StorableRoute>>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct StorableRoute {
     pub path: String,
     pub service: String,


### PR DESCRIPTION
Also added the `Debug` trait to `LocalState` which makes it possible to 
```
    println!("{:?}", state);
```
which can be useful for debug logging and troubleshooting.

part of do-1497