### PR TITLE
feat: paid tunnels v1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +909,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "linkup-cli"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -1126,6 +1155,7 @@ dependencies = [
  "colored",
  "ctrlc",
  "daemonize",
+ "env_logger",
  "hickory-resolver",
  "linkup",
  "linkup-local-server",

--- a/clear-unused-dns.ts
+++ b/clear-unused-dns.ts
@@ -1,9 +1,4 @@
-async function deleteTXTRecords(
-  recordName: string,
-  zoneId: string,
-  apiToken: string,
-  email: string
-) {
+async function deleteTXTRecords(zoneId: string) {
   const baseUrl = `https://api.cloudflare.com/client/v4/zones/${zoneId}/dns_records`;
 
   // Fetch all DNS records
@@ -11,24 +6,70 @@ async function deleteTXTRecords(
     const response = await fetch(`${baseUrl}?per_page=1000`, {
       headers: {
         "Content-Type": "application/json",
-        "X-Auth-Email": email,
-        "X-Auth-Key": apiToken,
+        Authorization: `Bearer ${api_token}`,
       },
     });
     const data = await response.json();
     return data.result.filter(
       (record: any) =>
-        record.type === "TXT" && record.name.startsWith(recordName)
+        record.type === "TXT" && record.name.startsWith("_acme-challenge")
     );
   };
 
+  const recordsToDelete = await getRecords();
+  await doBatchDelete(baseUrl, recordsToDelete);
+}
+
+async function deleteTunnelCNAMERecords() {
+  const baseUrl = `https://api.cloudflare.com/client/v4/zones/${mentimeter_dev_zone_id}/dns_records`;
+
+  // Fetch all DNS records
+  const getRecords = async () => {
+    const response = await fetch(`${baseUrl}?per_page=1000`, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${api_token}`,
+      },
+    });
+    const data = await response.json();
+    return data.result.filter(
+      (record: any) =>
+        record.type === "CNAME" && record.name.startsWith("tunnel-")
+    );
+  };
+
+  const recordsToDelete = await getRecords();
+  await doBatchDelete(baseUrl, recordsToDelete);
+}
+
+async function deleteTunnels() {
+  const baseUrl = `https://api.cloudflare.com/client/v4/accounts/${account_id}/cfd_tunnel`;
+
+  // Fetch all tunnels
+  const getRecords = async () => {
+    const response = await fetch(`${baseUrl}?per_page=1000`, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${api_token}`,
+      },
+    });
+    const data = await response.json();
+    return data.result.filter(
+      (tunnel: any) => tunnel.name.startsWith("tunnel-") && !tunnel.deleted_at
+    );
+  };
+
+  const recordsToDelete = await getRecords();
+  await doBatchDelete(baseUrl, recordsToDelete);
+}
+
+async function doBatchDelete(url: string, recordsToDelete: any[]) {
   const deleteRecord = async (id: string) => {
-    const response = await fetch(`${baseUrl}/${id}`, {
+    const response = await fetch(`${url}/${id}`, {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",
-        "X-Auth-Email": email,
-        "X-Auth-Key": apiToken,
+        Authorization: `Bearer ${api_token}`,
       },
     });
 
@@ -40,7 +81,6 @@ async function deleteTXTRecords(
     return response.json();
   };
 
-  const recordsToDelete = await getRecords();
   console.log("Records to delete:", recordsToDelete.length);
 
   // Batch deletion, 20 records at a time
@@ -56,18 +96,22 @@ async function deleteTXTRecords(
   await batchDelete(recordsToDelete);
 }
 
-const zones = process.argv.slice(2);
-const apikey = process.env.CLOUDFLARE_API_KEY;
-const email = process.env.CLOUDFLARE_EMAIL;
+const api_token = process.env.LINKUP_CF_API_TOKEN;
+const account_id = process.env.LINKUP_CLOUDFLARE_ACCOUNT_ID;
+const mentimeter_dev_zone_id = process.env.LINKUP_CLOUDFLARE_ZONE_ID;
 
-if (!apikey || !email) {
-  console.error("Missing Cloudflare API key or email");
+if (!api_token || !account_id || !mentimeter_dev_zone_id) {
+  console.error("Missing Cloudflare API Token, Account ID or Zone ID");
   console.error(
-    "Please set CLOUDFLARE_API_KEY and CLOUDFLARE_EMAIL environment variables"
+    "Please set LINKUP_CF_API_TOKEN, LINKUP_CLOUDFLARE_ACCOUNT_ID, and LINKUP_CLOUDFLARE_ZONE_ID environment variables"
   );
   process.exit(1);
 }
 
+deleteTunnelCNAMERecords();
+deleteTunnels();
+
+const zones = process.argv.slice(2);
 if (zones.length === 0) {
   console.error("No zones specified");
   console.error("Usage: clear-unused-dns.ts zone1 zone2 ...");
@@ -76,5 +120,5 @@ if (zones.length === 0) {
 
 for (const zone of zones) {
   console.log("Deleting records for zone:", zone);
-  deleteTXTRecords("_acme-challenge", zone, apikey, email);
+  deleteTXTRecords(zone);
 }

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkup-cli"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 
 [[bin]]
@@ -30,6 +30,7 @@ serde_yaml = "0.9"
 thiserror = "1"
 url = { version = "2.5", features = ["serde"] }
 base64 = "0.22.1"
+env_logger = "0.11.3"
 
 [dev-dependencies]
 mockall = "0.12.1"

--- a/linkup-cli/src/background_booting.rs
+++ b/linkup-cli/src/background_booting.rs
@@ -12,7 +12,7 @@ use url::Url;
 
 use crate::local_config::{LocalState, ServiceTarget};
 use crate::services::local_server::{is_local_server_started, start_local_server};
-use crate::services::tunnel::{is_tunnel_running, RealTunnelManager, TunnelManager};
+use crate::services::tunnel::{RealTunnelManager, TunnelManager};
 use crate::status::print_session_names;
 use crate::worker_client::WorkerClient;
 use crate::{linkup_file_path, services, LINKUP_LOCALSERVER_PORT};
@@ -21,6 +21,7 @@ use crate::{CliError, LINKUP_LOCALDNS_INSTALL};
 #[cfg_attr(test, mockall::automock)]
 pub trait BackgroundServices {
     fn boot_background_services(&self, state: LocalState) -> Result<LocalState, CliError>;
+    fn boot_local_dns(&self, domains: Vec<String>, session_name: String) -> Result<(), CliError>;
 }
 
 pub struct RealBackgroundServices;
@@ -40,19 +41,21 @@ impl BackgroundServices for RealBackgroundServices {
         wait_till_ok(format!("{}linkup-check", local_url))?;
 
         let should_run_free = state.linkup.is_paid.is_none() || !state.linkup.is_paid.unwrap();
-        if state.should_use_tunnel() && should_run_free {
-            if is_tunnel_running().is_err() {
-                println!("Starting tunnel...");
+        if should_run_free {
+            if state.should_use_tunnel() {
                 let tunnel_manager = RealTunnelManager {};
-                let tunnel = tunnel_manager.run_tunnel(&state)?;
-                state.linkup.tunnel = Some(tunnel);
+                if tunnel_manager.is_tunnel_running().is_err() {
+                    println!("Starting tunnel...");
+                    let tunnel = tunnel_manager.run_tunnel(&state)?;
+                    state.linkup.tunnel = Some(tunnel);
+                } else {
+                    println!("Cloudflare tunnel was already running.. Try stopping linkup first if you have problems.");
+                }
             } else {
-                println!("Cloudflare tunnel was already running.. Try stopping linkup first if you have problems.");
+                println!(
+                "Skipping tunnel start... WARNING: not all kinds of requests will work in this mode."
+            );
             }
-        } else {
-            println!(
-            "Skipping tunnel start... WARNING: not all kinds of requests will work in this mode."
-        );
         }
 
         let server_config = ServerConfig::from(&state);
@@ -72,21 +75,30 @@ impl BackgroundServices for RealBackgroundServices {
         state.linkup.session_name = server_session_name;
         state.save()?;
 
-        if linkup_file_path(LINKUP_LOCALDNS_INSTALL).exists() {
-            boot_local_dns(state.domain_strings(), state.linkup.session_name.clone())?;
-        }
+        if should_run_free {
+            if linkup_file_path(LINKUP_LOCALDNS_INSTALL).exists() {
+                self.boot_local_dns(state.domain_strings(), state.linkup.session_name.clone())?;
+            }
 
-        if let Some(tunnel) = &state.linkup.tunnel {
-            println!("Waiting for tunnel DNS to propagate at {}...", tunnel);
+            if let Some(tunnel) = &state.linkup.tunnel {
+                println!("Waiting for tunnel DNS to propagate at {}...", tunnel);
 
-            wait_for_dns_ok(tunnel.clone())?;
+                wait_for_dns_ok(tunnel.clone())?;
 
-            println!();
+                println!();
+            }
         }
 
         print_session_names(&state);
 
         Ok(state)
+    }
+
+    fn boot_local_dns(&self, domains: Vec<String>, session_name: String) -> Result<(), CliError> {
+        services::caddy::start(domains.clone())?;
+        services::dnsmasq::start(domains, session_name)?;
+
+        Ok(())
     }
 }
 
@@ -108,13 +120,6 @@ pub fn load_config(
         .map_err(|e| CliError::LoadConfig(url.to_string(), e.to_string()))?;
 
     Ok(content)
-}
-
-pub fn boot_local_dns(domains: Vec<String>, session_name: String) -> Result<(), CliError> {
-    services::caddy::start(domains.clone())?;
-    services::dnsmasq::start(domains, session_name)?;
-
-    Ok(())
 }
 
 pub struct ServerConfig {


### PR DESCRIPTION
Tested going from paid to free tunnel, and vice versa. Works smoothly for me at least 🤞 

Some extra logging added that shows up when running `RUST_LOG=info cargo run -- start`. There is more that can be done with logging but will leave that for the linear card DO-1495 "linkup: logger".

Part of DO-1495
Resolves DO-1496