### PR TITLE
fix: set linkup env vars in .envs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "linkup-cli"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkup-cli"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Sets env vars for both paid and free tunnels