### PR TITLE
Allow preview sessions to have cache_routes

### DIFF
--- a/linkup-cli/src/local_config.rs
+++ b/linkup-cli/src/local_config.rs
@@ -164,6 +164,7 @@ impl YamlLocalConfig {
         CreatePreviewRequest {
             services,
             domains: self.domains.clone(),
+            cache_routes: self.linkup.cache_routes.clone(),
         }
     }
 }
@@ -213,20 +214,13 @@ pub fn config_to_state(
     let services = yaml_config
         .services
         .into_iter()
-        .map(|yaml_service| {
-            let rewrites = match yaml_service.rewrites {
-                Some(modifiers) => modifiers,
-                None => Vec::new(),
-            };
-
-            LocalService {
-                name: yaml_service.name,
-                remote: yaml_service.remote,
-                local: yaml_service.local,
-                current: ServiceTarget::Remote,
-                directory: yaml_service.directory,
-                rewrites,
-            }
+        .map(|yaml_service| LocalService {
+            name: yaml_service.name,
+            remote: yaml_service.remote,
+            local: yaml_service.local,
+            current: ServiceTarget::Remote,
+            directory: yaml_service.directory,
+            rewrites: yaml_service.rewrites.unwrap_or_default(),
         })
         .collect::<Vec<LocalService>>();
 

--- a/linkup/src/session.rs
+++ b/linkup/src/session.rs
@@ -56,6 +56,7 @@ pub struct UpdateSessionRequest {
 pub struct CreatePreviewRequest {
     pub services: Vec<StorableService>,
     pub domains: Vec<StorableDomain>,
+    pub cache_routes: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -134,7 +135,7 @@ impl From<CreatePreviewRequest> for StorableSession {
             session_token: PREVIEW_SESSION_TOKEN.to_string(),
             services: req.services,
             domains: req.domains,
-            cache_routes: None,
+            cache_routes: req.cache_routes,
         }
     }
 }

--- a/server-tests/tests/server_test.rs
+++ b/server-tests/tests/server_test.rs
@@ -92,6 +92,7 @@ pub fn create_preview_request(fe_location: Option<String>) -> String {
             location: Url::parse(&location).unwrap(),
             rewrites: None,
         }],
+        cache_routes: None,
     };
     serde_json::to_string(&req).unwrap()
 }


### PR DESCRIPTION
Allow preview sessions to use the same `cache_routes` allowlist as normal environments. This means we can cache _next/static which reduces the load on heroku dynos