### PR TITLE
fix: use additional headers on status request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "linkup-cli"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/linkup-cli/src/start.rs
+++ b/linkup-cli/src/start.rs
@@ -41,9 +41,8 @@ pub fn start(config_arg: &Option<String>, no_tunnel: bool) -> Result<(), CliErro
 fn set_linkup_env(state: LocalState) -> Result<(), CliError> {
     // Set env vars to linkup
     for service in &state.services {
-        match &service.directory {
-            Some(d) => set_service_env(d.clone(), state.linkup.config_path.clone())?,
-            None => {}
+        if let Some(d) = &service.directory {
+            set_service_env(d.clone(), state.linkup.config_path.clone())?
         }
     }
     Ok(())

--- a/linkup-cli/src/start.rs
+++ b/linkup-cli/src/start.rs
@@ -202,7 +202,7 @@ fn check_local_not_started() -> Result<(), CliError> {
         if service.local == service.remote {
             continue;
         }
-        if server_status(service.local.to_string()) == ServerStatus::Ok {
+        if server_status(service.local.to_string(), None) == ServerStatus::Ok {
             println!("⚠️  Service {} is already running locally!! You need to restart it for linkup's environment variables to be loaded.", service.name);
         }
     }


### PR DESCRIPTION
### Description
When we check the status of a service, we are not sending the extra headers, like we do for normal requests. With this change, we make sure to add the additional requests to the services when doing status check as well.

Closes DO-1755