### PR TITLE
chore: fix Cargo warnings

### DIFF
--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -26,7 +26,7 @@ reqwest = { version = "0.12.4", default-features = false, features = [
 ] }
 serde = "1.0.210"
 serde_json = "1.0.129"
-serde_yaml = "0.9.34+deprecated"
+serde_yaml = "0.9.34"
 thiserror = "1.0.64"
 url = { version = "2.5.2", features = ["serde"] }
 base64 = "0.22.1"

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-axum = { version = "0.7.5", features = ["json"], default_features = false }
+axum = { version = "0.7.5", features = ["json"], default-features = false }
 console_error_panic_hook = { version = "0.1.7" }
 futures = "0.3.31"
 getrandom = { version = "0.2.15", features = ["js"] }


### PR DESCRIPTION
The following warnings are fixed by these changes:
- warning: version requirement `0.9.34+deprecated` for dependency `serde_yaml` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
- warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition (in the `axum` dependency)