### PR TITLE
feat: create health command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,9 +1077,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
 
 [[package]]
 name = "libloading"
@@ -1113,6 +1138,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sysinfo",
  "thiserror",
  "url",
 ]
@@ -1303,6 +1329,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1553,6 +1588,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2067,6 +2122,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2521,13 +2590,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -2546,7 +2668,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
 ]
 

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -32,6 +32,7 @@ url = { version = "2.5.2", features = ["serde"] }
 base64 = "0.22.1"
 env_logger = "0.11.5"
 crossterm = "0.28.1"
+sysinfo = "0.32.1"
 
 [dev-dependencies]
 mockall = "0.13.0"

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -8,7 +8,7 @@ name = "linkup"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.5.20", features = ["derive"] }
+clap = { version = "4.5.20", features = ["derive", "cargo"] }
 clap_complete = "4.5.33"
 colored = "2.1.0"
 ctrlc = { version = "3.4.5", features = ["termination"] }

--- a/linkup-cli/src/health.rs
+++ b/linkup-cli/src/health.rs
@@ -5,10 +5,11 @@ use std::{
 };
 
 use colored::Colorize;
+use serde::Serialize;
 
 use crate::{linkup_dir_path, local_config::LocalState, CliError};
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 struct System {
     os_name: String,
     os_version: String,
@@ -23,7 +24,7 @@ impl System {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 struct Session {
     name: String,
 }
@@ -38,7 +39,7 @@ impl Session {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 struct EnvironmentVariables {
     cf_api_token: bool,
     cf_zone_id: bool,
@@ -55,7 +56,7 @@ impl EnvironmentVariables {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 struct BackgroudServices {
     caddy_pids: Vec<String>,
     dnsmasq_pids: Vec<String>,
@@ -91,7 +92,7 @@ impl BackgroudServices {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 struct LinkupDir {
     location: String,
     content: Vec<String>,
@@ -111,7 +112,7 @@ impl LinkupDir {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 struct Health {
     system: System,
     session: Session,
@@ -215,8 +216,15 @@ impl Display for Health {
     }
 }
 
-pub fn health() -> Result<(), CliError> {
+pub fn health(json: bool) -> Result<(), CliError> {
     let health = Health::load()?;
+
+    let health = if json {
+        serde_json::to_string_pretty(&health).unwrap()
+    } else {
+        format!("{}", health)
+    };
+
     println!("{}", health);
 
     Ok(())

--- a/linkup-cli/src/health.rs
+++ b/linkup-cli/src/health.rs
@@ -104,7 +104,7 @@ impl Linkup {
     fn load() -> Result<Self, CliError> {
         let dir_path = linkup_dir_path();
         let files: Vec<String> = fs::read_dir(&dir_path)?
-            .map(|f| f.unwrap().file_name().to_str().unwrap().to_string())
+            .map(|f| f.unwrap().file_name().into_string().unwrap())
             .collect();
 
         Ok(Self {

--- a/linkup-cli/src/health.rs
+++ b/linkup-cli/src/health.rs
@@ -4,6 +4,7 @@ use std::{
     fs::{self},
 };
 
+use clap::crate_version;
 use colored::Colorize;
 use serde::Serialize;
 
@@ -93,12 +94,13 @@ impl BackgroudServices {
 }
 
 #[derive(Debug, Serialize)]
-struct LinkupDir {
-    location: String,
-    content: Vec<String>,
+struct Linkup {
+    version: String,
+    config_location: String,
+    config_content: Vec<String>,
 }
 
-impl LinkupDir {
+impl Linkup {
     fn load() -> Result<Self, CliError> {
         let dir_path = linkup_dir_path();
         let files: Vec<String> = fs::read_dir(&dir_path)?
@@ -106,8 +108,9 @@ impl LinkupDir {
             .collect();
 
         Ok(Self {
-            location: dir_path.to_str().unwrap_or_default().to_string(),
-            content: files,
+            version: crate_version!().to_string(),
+            config_location: dir_path.to_str().unwrap_or_default().to_string(),
+            config_content: files,
         })
     }
 }
@@ -118,7 +121,7 @@ struct Health {
     session: Session,
     environment_variables: EnvironmentVariables,
     background_services: BackgroudServices,
-    linkup_dir: LinkupDir,
+    linkup: Linkup,
 }
 
 impl Health {
@@ -128,7 +131,7 @@ impl Health {
             session: Session::load()?,
             environment_variables: EnvironmentVariables::load(),
             background_services: BackgroudServices::load(),
-            linkup_dir: LinkupDir::load()?,
+            linkup: Linkup::load()?,
         })
     }
 }
@@ -205,10 +208,11 @@ impl Display for Health {
             writeln!(f, "{}", "MISSING".yellow())?;
         }
 
-        writeln!(f, "{}", "Linkup dir:".bold().italic())?;
-        writeln!(f, "  Location: {}", self.linkup_dir.location)?;
-        writeln!(f, "  Content:")?;
-        for file in &self.linkup_dir.content {
+        writeln!(f, "{}", "Linkup:".bold().italic())?;
+        writeln!(f, "  Version: {}", self.linkup.version)?;
+        writeln!(f, "  Config location: {}", self.linkup.config_location)?;
+        writeln!(f, "  Config contents:")?;
+        for file in &self.linkup.config_content {
             writeln!(f, "    - {}", file)?;
         }
 

--- a/linkup-cli/src/health.rs
+++ b/linkup-cli/src/health.rs
@@ -1,139 +1,223 @@
 use std::{
     env,
-    fs::{self, File},
-    io::Read,
+    fmt::Display,
+    fs::{self},
 };
 
 use colored::Colorize;
-use sysinfo::System;
 
 use crate::{linkup_dir_path, local_config::LocalState, CliError};
 
+#[derive(Debug)]
+struct System {
+    os_name: String,
+    os_version: String,
+}
+
+impl System {
+    fn load() -> Self {
+        Self {
+            os_name: sysinfo::System::name().unwrap(),
+            os_version: sysinfo::System::os_version().unwrap(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Session {
+    name: String,
+}
+
+impl Session {
+    fn load() -> Result<Self, CliError> {
+        let state = LocalState::load()?;
+
+        Ok(Self {
+            name: state.linkup.session_name,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct EnvironmentVariables {
+    cf_api_token: bool,
+    cf_zone_id: bool,
+    cf_account_id: bool,
+}
+
+impl EnvironmentVariables {
+    fn load() -> Self {
+        Self {
+            cf_api_token: env::var("LINKUP_CF_API_TOKEN").is_ok(),
+            cf_zone_id: env::var("LINKUP_CLOUDFLARE_ZONE_ID").is_ok(),
+            cf_account_id: env::var("LINKUP_CLOUDFLARE_ACCOUNT_ID").is_ok(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct BackgroudServices {
+    caddy_pids: Vec<String>,
+    dnsmasq_pids: Vec<String>,
+    cloudflared_pids: Vec<String>,
+}
+
+impl BackgroudServices {
+    fn load() -> Self {
+        let mut sys = sysinfo::System::new_all();
+        sys.refresh_all();
+
+        let mut dnsmasq_pids: Vec<String> = vec![];
+        let mut caddy_pids: Vec<String> = vec![];
+        let mut cloudflared_pids: Vec<String> = vec![];
+
+        for (pid, process) in sys.processes() {
+            let process_name = process.name();
+
+            if process_name == "dnsmasq" {
+                dnsmasq_pids.push(pid.to_string());
+            } else if process_name == "caddy" {
+                caddy_pids.push(pid.to_string());
+            } else if process_name == "cloudflared" {
+                cloudflared_pids.push(pid.to_string());
+            }
+        }
+
+        Self {
+            caddy_pids,
+            cloudflared_pids,
+            dnsmasq_pids,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct LinkupDir {
+    location: String,
+    content: Vec<String>,
+}
+
+impl LinkupDir {
+    fn load() -> Result<Self, CliError> {
+        let dir_path = linkup_dir_path();
+        let files: Vec<String> = fs::read_dir(&dir_path)?
+            .map(|f| f.unwrap().file_name().to_str().unwrap().to_string())
+            .collect();
+
+        Ok(Self {
+            location: dir_path.to_str().unwrap_or_default().to_string(),
+            content: files,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct Health {
+    system: System,
+    session: Session,
+    environment_variables: EnvironmentVariables,
+    background_services: BackgroudServices,
+    linkup_dir: LinkupDir,
+}
+
+impl Health {
+    pub fn load() -> Result<Self, CliError> {
+        Ok(Self {
+            system: System::load(),
+            session: Session::load()?,
+            environment_variables: EnvironmentVariables::load(),
+            background_services: BackgroudServices::load(),
+            linkup_dir: LinkupDir::load()?,
+        })
+    }
+}
+
+impl Display for Health {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{}", "System info:".bold().italic())?;
+        writeln!(
+            f,
+            "  OS: {} ({})",
+            self.system.os_name, self.system.os_version,
+        )?;
+
+        writeln!(f, "{}", "Session info:".bold().italic())?;
+        writeln!(f, "  Name: {}", self.session.name)?;
+
+        writeln!(f, "{}", "Background sevices:".bold().italic())?;
+        write!(f, "  - Caddy       ")?;
+        if !self.background_services.caddy_pids.is_empty() {
+            writeln!(
+                f,
+                "{} ({})",
+                "RUNNING".blue(),
+                self.background_services.caddy_pids.join(",")
+            )?;
+        } else {
+            writeln!(f, "{}", "NOT RUNNING".yellow())?;
+        }
+
+        write!(f, "  - dnsmasq     ")?;
+        if !self.background_services.dnsmasq_pids.is_empty() {
+            writeln!(
+                f,
+                "{} ({})",
+                "RUNNING".blue(),
+                self.background_services.dnsmasq_pids.join(",")
+            )?;
+        } else {
+            writeln!(f, "{}", "NOT RUNNING".yellow())?;
+        }
+
+        write!(f, "  - Cloudflared ")?;
+        if !self.background_services.cloudflared_pids.is_empty() {
+            writeln!(
+                f,
+                "{} ({})",
+                "RUNNING".blue(),
+                self.background_services.cloudflared_pids.join(",")
+            )?;
+        } else {
+            writeln!(f, "{}", "NOT RUNNING".yellow())?;
+        }
+
+        writeln!(f, "{}", "Environment variables:".bold().italic())?;
+
+        write!(f, "  - LINKUP_CF_API_TOKEN          ")?;
+        if self.environment_variables.cf_api_token {
+            writeln!(f, "{}", "OK".blue())?;
+        } else {
+            writeln!(f, "{}", "MISSING".yellow())?;
+        }
+
+        write!(f, "  - LINKUP_CLOUDFLARE_ZONE_ID    ")?;
+        if self.environment_variables.cf_zone_id {
+            writeln!(f, "{}", "OK".blue())?;
+        } else {
+            writeln!(f, "{}", "MISSING".yellow())?;
+        }
+
+        write!(f, "  - LINKUP_CLOUDFLARE_ACCOUNT_ID ")?;
+        if self.environment_variables.cf_account_id {
+            writeln!(f, "{}", "OK".blue())?;
+        } else {
+            writeln!(f, "{}", "MISSING".yellow())?;
+        }
+
+        writeln!(f, "{}", "Linkup dir:".bold().italic())?;
+        writeln!(f, "  Location: {}", self.linkup_dir.location)?;
+        writeln!(f, "  Content:")?;
+        for file in &self.linkup_dir.content {
+            writeln!(f, "    - {}", file)?;
+        }
+
+        Ok(())
+    }
+}
+
 pub fn health() -> Result<(), CliError> {
-    system_info()?;
-    println!();
-    session_info()?;
-    println!();
-    backgroud_services()?;
-    println!();
-    env_variables()?;
-    println!();
-    linkup_folder_content()?;
-
-    Ok(())
-}
-
-fn env_variables() -> Result<(), CliError> {
-    println!("{}", "Environment variables:".bold().italic());
-
-    let expected_vars = [
-        "LINKUP_CF_API_TOKEN",
-        "LINKUP_CLOUDFLARE_ZONE_ID",
-        "LINKUP_CLOUDFLARE_ACCOUNT_ID",
-    ];
-
-    for var in expected_vars {
-        print!("  {:30}", var);
-        match env::var(var) {
-            Ok(_) => println!("{}", "OK".blue()),
-            Err(_) => println!("{}", "MISSING".yellow()),
-        }
-    }
-
-    Ok(())
-}
-
-fn session_info() -> Result<(), CliError> {
-    let state = LocalState::load()?;
-    println!("{}", "Session info:".bold().italic());
-    println!("  Name: {}", state.linkup.session_name);
-
-    Ok(())
-}
-
-fn linkup_folder_content() -> Result<(), CliError> {
-    println!("{}", "Linkup Dir:".bold().italic());
-
-    let dir_path = linkup_dir_path();
-
-    println!("  Location: {}", dir_path.to_str().unwrap());
-
-    println!("  Content:");
-    for entry in fs::read_dir(dir_path)? {
-        let entry = entry?;
-        let file_name = entry.file_name().to_str().unwrap().to_string();
-        let file_path = entry.path();
-
-        print!("    {}", &file_name);
-
-        if file_name.ends_with("-pid") {
-            let mut file = File::open(file_path).unwrap();
-            let mut pid = String::new();
-            file.read_to_string(&mut pid)?;
-
-            print!(" ({})", pid.trim());
-        }
-
-        println!();
-    }
-
-    Ok(())
-}
-
-fn system_info() -> Result<(), CliError> {
-    println!("{}", "System info:".bold().italic());
-
-    println!(
-        "  OS: {} ({})",
-        System::name().unwrap(),
-        System::os_version().unwrap()
-    );
-
-    Ok(())
-}
-
-fn backgroud_services() -> Result<(), CliError> {
-    println!("{}", "Background sevices:".bold().italic());
-
-    let mut sys = System::new_all();
-    sys.refresh_all();
-
-    let mut local_dns_pids: Vec<String> = vec![];
-    let mut caddy_pids: Vec<String> = vec![];
-    let mut cloudflared_pids: Vec<String> = vec![];
-
-    for (pid, process) in sys.processes() {
-        let process_name = process.name();
-
-        if process_name == "dnsmasq" {
-            local_dns_pids.push(pid.to_string());
-        } else if process_name == "caddy" {
-            caddy_pids.push(pid.to_string());
-        } else if process_name == "cloudflared" {
-            cloudflared_pids.push(pid.to_string());
-        }
-    }
-
-    print!("  Caddy        ");
-    if !caddy_pids.is_empty() {
-        println!("{} ({})", "RUNNING".blue(), caddy_pids.join(","))
-    } else {
-        println!("{}", "NOT RUNNING".yellow())
-    }
-
-    print!("  Local DNS    ");
-    if !local_dns_pids.is_empty() {
-        println!("{} ({})", "RUNNING".blue(), local_dns_pids.join(","));
-    } else {
-        println!("{}", "NOT RUNNING".yellow());
-    }
-
-    print!("  Cloudflared  ");
-    if !cloudflared_pids.is_empty() {
-        println!("{} ({})", "RUNNING".blue(), cloudflared_pids.join(","));
-    } else {
-        println!("{}", "NOT RUNNING".yellow());
-    }
+    let health = Health::load()?;
+    println!("{}", health);
 
     Ok(())
 }

--- a/linkup-cli/src/health.rs
+++ b/linkup-cli/src/health.rs
@@ -1,0 +1,139 @@
+use std::{
+    env,
+    fs::{self, File},
+    io::Read,
+};
+
+use colored::Colorize;
+use sysinfo::System;
+
+use crate::{linkup_dir_path, local_config::LocalState, CliError};
+
+pub fn health() -> Result<(), CliError> {
+    system_info()?;
+    println!();
+    session_info()?;
+    println!();
+    backgroud_services()?;
+    println!();
+    env_variables()?;
+    println!();
+    linkup_folder_content()?;
+
+    Ok(())
+}
+
+fn env_variables() -> Result<(), CliError> {
+    println!("{}", "Environment variables:".bold().italic());
+
+    let expected_vars = [
+        "LINKUP_CF_API_TOKEN",
+        "LINKUP_CLOUDFLARE_ZONE_ID",
+        "LINKUP_CLOUDFLARE_ACCOUNT_ID",
+    ];
+
+    for var in expected_vars {
+        print!("  {:30}", var);
+        match env::var(var) {
+            Ok(_) => println!("{}", "OK".blue()),
+            Err(_) => println!("{}", "MISSING".yellow()),
+        }
+    }
+
+    Ok(())
+}
+
+fn session_info() -> Result<(), CliError> {
+    let state = LocalState::load()?;
+    println!("{}", "Session info:".bold().italic());
+    println!("  Name: {}", state.linkup.session_name);
+
+    Ok(())
+}
+
+fn linkup_folder_content() -> Result<(), CliError> {
+    println!("{}", "Linkup Dir:".bold().italic());
+
+    let dir_path = linkup_dir_path();
+
+    println!("  Location: {}", dir_path.to_str().unwrap());
+
+    println!("  Content:");
+    for entry in fs::read_dir(dir_path)? {
+        let entry = entry?;
+        let file_name = entry.file_name().to_str().unwrap().to_string();
+        let file_path = entry.path();
+
+        print!("    {}", &file_name);
+
+        if file_name.ends_with("-pid") {
+            let mut file = File::open(file_path).unwrap();
+            let mut pid = String::new();
+            file.read_to_string(&mut pid)?;
+
+            print!(" ({})", pid.trim());
+        }
+
+        println!();
+    }
+
+    Ok(())
+}
+
+fn system_info() -> Result<(), CliError> {
+    println!("{}", "System info:".bold().italic());
+
+    println!(
+        "  OS: {} ({})",
+        System::name().unwrap(),
+        System::os_version().unwrap()
+    );
+
+    Ok(())
+}
+
+fn backgroud_services() -> Result<(), CliError> {
+    println!("{}", "Background sevices:".bold().italic());
+
+    let mut sys = System::new_all();
+    sys.refresh_all();
+
+    let mut local_dns_pids: Vec<String> = vec![];
+    let mut caddy_pids: Vec<String> = vec![];
+    let mut cloudflared_pids: Vec<String> = vec![];
+
+    for (pid, process) in sys.processes() {
+        let process_name = process.name();
+
+        if process_name == "dnsmasq" {
+            local_dns_pids.push(pid.to_string());
+        } else if process_name == "caddy" {
+            caddy_pids.push(pid.to_string());
+        } else if process_name == "cloudflared" {
+            cloudflared_pids.push(pid.to_string());
+        }
+    }
+
+    print!("  Caddy        ");
+    if !caddy_pids.is_empty() {
+        println!("{} ({})", "RUNNING".blue(), caddy_pids.join(","))
+    } else {
+        println!("{}", "NOT RUNNING".yellow())
+    }
+
+    print!("  Local DNS    ");
+    if !local_dns_pids.is_empty() {
+        println!("{} ({})", "RUNNING".blue(), local_dns_pids.join(","));
+    } else {
+        println!("{}", "NOT RUNNING".yellow());
+    }
+
+    print!("  Cloudflared  ");
+    if !cloudflared_pids.is_empty() {
+        println!("{} ({})", "RUNNING".blue(), cloudflared_pids.join(","));
+    } else {
+        println!("{}", "NOT RUNNING".yellow());
+    }
+
+    Ok(())
+}

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -3,11 +3,13 @@ use std::{env, fs, io::ErrorKind, path::PathBuf};
 use clap::{builder::ValueParser, Parser, Subcommand};
 use clap_complete::Shell;
 use colored::Colorize;
+use health::health;
 use thiserror::Error;
 
 mod background_booting;
 mod completion;
 mod env_files;
+mod health;
 mod local_config;
 mod local_dns;
 mod paid_tunnel;
@@ -129,6 +131,8 @@ pub enum CliError {
     ParseErr(String, String),
     #[error("{0}: {1}")]
     FileErr(String, String),
+    #[error("{0}")]
+    IOError(#[from] std::io::Error),
 }
 
 #[derive(Error, Debug)]
@@ -166,6 +170,9 @@ enum LocalDNSSubcommand {
 
 #[derive(Subcommand)]
 enum Commands {
+    #[clap(about = "Output the health of the CLI service")]
+    Health {},
+
     #[clap(about = "Start a new linkup session")]
     Start {
         #[clap(
@@ -248,6 +255,7 @@ fn main() -> Result<()> {
     ensure_linkup_dir()?;
 
     match &cli.command {
+        Commands::Health {} => health(),
         Commands::Start { no_tunnel } => start(&cli.config, *no_tunnel),
         Commands::Stop => stop(),
         Commands::Reset => reset(),

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -171,7 +171,11 @@ enum LocalDNSSubcommand {
 #[derive(Subcommand)]
 enum Commands {
     #[clap(about = "Output the health of the CLI service")]
-    Health {},
+    Health {
+        // Output status in JSON format
+        #[arg(long)]
+        json: bool,
+    },
 
     #[clap(about = "Start a new linkup session")]
     Start {
@@ -255,7 +259,7 @@ fn main() -> Result<()> {
     ensure_linkup_dir()?;
 
     match &cli.command {
-        Commands::Health {} => health(),
+        Commands::Health { json } => health(*json),
         Commands::Start { no_tunnel } => start(&cli.config, *no_tunnel),
         Commands::Stop => stop(),
         Commands::Reset => reset(),


### PR DESCRIPTION
We have very often to instruct people to do some steps and verify some local settings so that we can have an idea of what might be wrong with their environment.
It would be good for Linkup to have a command that output the overall health so that we can just get the dump from this command and have an idea of what might be wrong.

### TODO
- [x] ~Make it printable as json~ 6dddbc1993df7e819ade00b33b43bfb08f27fae4

### Example of current output (2024-11-29)
```
System info:
  OS: Darwin (14.6.1)
Session info:
  Name: sandy-camel
Background sevices:
  - Caddy       RUNNING (76550)
  - dnsmasq     RUNNING (76565)
  - Cloudflared RUNNING (76530)
Environment variables:
  - LINKUP_CF_API_TOKEN          OK
  - LINKUP_CLOUDFLARE_ZONE_ID    OK
  - LINKUP_CLOUDFLARE_ACCOUNT_ID OK
Linkup:
  Version: 1.2.1
  Config location: $HOME/.linkup
  Config contents:
    - dnsmasq-log
    - localserver-stdout
    - dnsmasq-pid
    - localserver-pid
    - cloudflared-pid
    - localserver-stderr
    - state
    - cloudflared-stdout
    - Caddyfile
    - localdns-install
    - caddy-log
    - dnsmasq-conf
    - cloudflared-stderr
    - caddy-pid
Local DNS resolvers:
    - <resolver_1>
    - <resolver_2>
```