### PR TITLE
chore: small QOL improvements

### DIFF
--- a/linkup-cli/src/start.rs
+++ b/linkup-cli/src/start.rs
@@ -239,7 +239,7 @@ mod tests {
     }
 
     fn make_state(session_name: &str) -> LocalState {
-        return LocalState {
+        LocalState {
             linkup: {
                 LinkupState {
                     session_name: session_name.to_string(),
@@ -253,7 +253,7 @@ mod tests {
             },
             services: vec![],
             domains: vec![],
-        };
+        }
     }
 
     #[test]

--- a/linkup-cli/src/status.rs
+++ b/linkup-cli/src/status.rs
@@ -108,8 +108,8 @@ pub fn status(json: bool) -> Result<(), CliError> {
     } else {
         print_session_status(&status.session);
         println!(
-            "{:<20} {:<20} {:<20} {:<20}",
-            "SERVICE NAME", "COMPONENT KIND", "STATUS", "LOCATION"
+            "{:<20} {:<15} {:<8} LOCATION",
+            "SERVICE NAME", "COMPONENT KIND", "STATUS",
         );
 
         stdout().execute(cursor::Hide).unwrap();
@@ -159,7 +159,7 @@ pub fn status(json: bool) -> Result<(), CliError> {
                 };
 
                 let display_status = &format!(
-                    "{:<20} {:<20} {:<20} {:<20}\n",
+                    "{:<20} {:<15} {:<8} {}\n",
                     status_name, status_component_kind, display_status, status_location
                 );
 

--- a/linkup-cli/src/status.rs
+++ b/linkup-cli/src/status.rs
@@ -113,6 +113,11 @@ pub fn status(json: bool) -> Result<(), CliError> {
         );
 
         stdout().execute(cursor::Hide).unwrap();
+        ctrlc::set_handler(move || {
+            stdout().execute(cursor::Show).unwrap();
+            std::process::exit(130);
+        })
+        .expect("Failed to set CTRL+C handler");
 
         let mut iteration = 0;
         let mut loading_char_iteration = 0;


### PR DESCRIPTION
### Changes
- [fix: ensure cursor is displayed back in case of ctrl+c](https://github.com/mentimeter/linkup/commit/2dd252784a0fe21a5bda6243eb55f7a16daf66b3)
- [style: make status output more compact](https://github.com/mentimeter/linkup/commit/a5cccffbe192feb547b63e733c45bad1c3fd2ba3)
- [lint: remove unnecessary return](https://github.com/mentimeter/linkup/commit/06e39886875fc4b1d1acf93e29b0cc06d0c402be)