### PR TITLE
Untangle background boot cleanup 1

### DIFF
--- a/linkup-cli/src/background_booting.rs
+++ b/linkup-cli/src/background_booting.rs
@@ -12,7 +12,7 @@ use url::Url;
 
 use crate::local_config::{LocalState, ServiceTarget};
 use crate::services::local_server::{is_local_server_started, start_local_server};
-use crate::services::tunnel::{RealTunnelManager, TunnelManager};
+use crate::services::tunnel::{CfTunnelManager, TunnelManager};
 use crate::status::print_session_names;
 use crate::worker_client::WorkerClient;
 use crate::{linkup_file_path, services, LINKUP_LOCALSERVER_PORT};
@@ -20,14 +20,15 @@ use crate::{CliError, LINKUP_LOCALDNS_INSTALL};
 
 #[cfg_attr(test, mockall::automock)]
 pub trait BackgroundServices {
+    fn boot_linkup_server(&self, state: LocalState) -> Result<LocalState, CliError>;
     fn boot_background_services(&self, state: LocalState) -> Result<LocalState, CliError>;
     fn boot_local_dns(&self, domains: Vec<String>, session_name: String) -> Result<(), CliError>;
 }
 
-pub struct RealBackgroundServices;
+pub struct LocalBackgroundServices;
 
-impl BackgroundServices for RealBackgroundServices {
-    fn boot_background_services(&self, mut state: LocalState) -> Result<LocalState, CliError> {
+impl BackgroundServices for LocalBackgroundServices {
+    fn boot_linkup_server(&self, mut state: LocalState) -> Result<LocalState, CliError> {
         let local_url = Url::parse(&format!("http://localhost:{}", LINKUP_LOCALSERVER_PORT))
             .expect("linkup url invalid");
 
@@ -39,24 +40,6 @@ impl BackgroundServices for RealBackgroundServices {
         }
 
         wait_till_ok(format!("{}linkup-check", local_url))?;
-
-        let should_run_free = state.linkup.is_paid.is_none() || !state.linkup.is_paid.unwrap();
-        if should_run_free {
-            if state.should_use_tunnel() {
-                let tunnel_manager = RealTunnelManager {};
-                if tunnel_manager.is_tunnel_running().is_err() {
-                    println!("Starting tunnel...");
-                    let tunnel = tunnel_manager.run_tunnel(&state)?;
-                    state.linkup.tunnel = Some(tunnel);
-                } else {
-                    println!("Cloudflare tunnel was already running.. Try stopping linkup first if you have problems.");
-                }
-            } else {
-                println!(
-                "Skipping tunnel start... WARNING: not all kinds of requests will work in this mode."
-            );
-            }
-        }
 
         let server_config = ServerConfig::from(&state);
 
@@ -75,6 +58,37 @@ impl BackgroundServices for RealBackgroundServices {
         state.linkup.session_name = server_session_name;
         state.save()?;
 
+        Ok(state)
+    }
+
+    fn boot_local_dns(&self, domains: Vec<String>, session_name: String) -> Result<(), CliError> {
+        services::caddy::start(domains.clone())?;
+        services::dnsmasq::start(domains, session_name)?;
+
+        Ok(())
+    }
+
+    fn boot_background_services(&self, mut state: LocalState) -> Result<LocalState, CliError> {
+        state = self.boot_linkup_server(state)?;
+
+        let should_run_free = state.linkup.is_paid.is_none() || !state.linkup.is_paid.unwrap();
+        if should_run_free {
+            if state.should_use_tunnel() {
+                let tunnel_manager = CfTunnelManager {};
+                if tunnel_manager.is_tunnel_running().is_err() {
+                    println!("Starting tunnel...");
+                    let tunnel = tunnel_manager.run_tunnel(&state)?;
+                    state.linkup.tunnel = Some(tunnel);
+                } else {
+                    println!("Cloudflare tunnel was already running.. Try stopping linkup first if you have problems.");
+                }
+            } else {
+                println!(
+                "Skipping tunnel start... WARNING: not all kinds of requests will work in this mode."
+            );
+            }
+        }
+
         if should_run_free {
             if linkup_file_path(LINKUP_LOCALDNS_INSTALL).exists() {
                 self.boot_local_dns(state.domain_strings(), state.linkup.session_name.clone())?;
@@ -92,13 +106,6 @@ impl BackgroundServices for RealBackgroundServices {
         print_session_names(&state);
 
         Ok(state)
-    }
-
-    fn boot_local_dns(&self, domains: Vec<String>, session_name: String) -> Result<(), CliError> {
-        services::caddy::start(domains.clone())?;
-        services::dnsmasq::start(domains, session_name)?;
-
-        Ok(())
     }
 }
 

--- a/linkup-cli/src/paid_tunnel.rs
+++ b/linkup-cli/src/paid_tunnel.rs
@@ -126,9 +126,9 @@ pub trait PaidTunnelManager {
     fn create_dns_record(&self, tunnel_id: &str, tunnel_name: &str) -> Result<(), CliError>;
 }
 
-pub struct RealPaidTunnelManager;
+pub struct CfPaidTunnelManager;
 
-impl PaidTunnelManager for RealPaidTunnelManager {
+impl PaidTunnelManager for CfPaidTunnelManager {
     fn get_tunnel_id(&self, tunnel_name: &str) -> Result<Option<String>, CliError> {
         let account_id = env::var("LINKUP_CLOUDFLARE_ACCOUNT_ID")
             .map_err(|_| CliError::GetEnvVar("LINKUP_CLOUDFLARE_ACCOUNT_ID".to_string()))?;

--- a/linkup-cli/src/reset.rs
+++ b/linkup-cli/src/reset.rs
@@ -11,7 +11,7 @@ pub fn reset() -> Result<(), CliError> {
 
     shutdown()?;
     let background_service = LocalBackgroundServices;
-    let _ = background_service.boot_background_services(state);
+    let _ = background_service.boot_linkup_server(state);
 
     Ok(())
 }

--- a/linkup-cli/src/reset.rs
+++ b/linkup-cli/src/reset.rs
@@ -1,5 +1,5 @@
 use crate::{
-    background_booting::{BackgroundServices, RealBackgroundServices},
+    background_booting::{BackgroundServices, LocalBackgroundServices},
     local_config::LocalState,
     stop::shutdown,
     CliError,
@@ -10,7 +10,7 @@ pub fn reset() -> Result<(), CliError> {
     let state = LocalState::load()?;
 
     shutdown()?;
-    let background_service = RealBackgroundServices;
+    let background_service = LocalBackgroundServices;
     let _ = background_service.boot_background_services(state);
 
     Ok(())

--- a/linkup-cli/src/services/tunnel.rs
+++ b/linkup-cli/src/services/tunnel.rs
@@ -28,9 +28,9 @@ pub trait TunnelManager {
     fn is_tunnel_running(&self) -> Result<(), CheckErr>;
 }
 
-pub struct RealTunnelManager;
+pub struct CfTunnelManager;
 
-impl TunnelManager for RealTunnelManager {
+impl TunnelManager for CfTunnelManager {
     fn run_tunnel(&self, state: &LocalState) -> Result<Url, CliError> {
         let mut attempt = 0;
         loop {

--- a/linkup-cli/src/start.rs
+++ b/linkup-cli/src/start.rs
@@ -6,12 +6,12 @@ use std::{
 use colored::Colorize;
 
 use crate::{
-    background_booting::{BackgroundServices, RealBackgroundServices},
+    background_booting::{BackgroundServices, LocalBackgroundServices},
     env_files::write_to_env_file,
     linkup_file_path,
     local_config::{config_path, config_to_state, get_config},
-    paid_tunnel::{PaidTunnelManager, RealPaidTunnelManager},
-    services::tunnel::{RealTunnelManager, TunnelManager},
+    paid_tunnel::{CfPaidTunnelManager, PaidTunnelManager},
+    services::tunnel::{CfTunnelManager, TunnelManager},
     system::{RealSystem, System},
     LINKUP_LOCALDNS_INSTALL,
 };
@@ -29,9 +29,9 @@ pub fn start(config_arg: &Option<String>, no_tunnel: bool) -> Result<(), CliErro
     if is_paid {
         start_paid_tunnel(
             &RealSystem,
-            &RealPaidTunnelManager,
-            &RealBackgroundServices,
-            &RealTunnelManager,
+            &CfPaidTunnelManager,
+            &LocalBackgroundServices,
+            &CfTunnelManager,
             state,
         )?;
     } else {
@@ -124,7 +124,7 @@ fn start_free_tunnel(state: LocalState, no_tunnel: bool) -> Result<(), CliError>
         return Err(CliError::NoTunnelWithoutLocalDns);
     }
 
-    let background_service = RealBackgroundServices {};
+    let background_service = LocalBackgroundServices {};
     let state = background_service.boot_background_services(state)?;
 
     check_local_not_started(&state)?;

--- a/linkup-cli/src/start.rs
+++ b/linkup-cli/src/start.rs
@@ -6,12 +6,13 @@ use std::{
 use colored::Colorize;
 
 use crate::{
-    background_booting::{BackgroundServices, LocalBackgroundServices},
+    background_booting::{wait_for_dns_ok, BackgroundServices, LocalBackgroundServices},
     env_files::write_to_env_file,
     linkup_file_path,
     local_config::{config_path, config_to_state, get_config},
     paid_tunnel::{CfPaidTunnelManager, PaidTunnelManager},
     services::tunnel::{CfTunnelManager, TunnelManager},
+    status::print_session_names,
     system::{RealSystem, System},
     LINKUP_LOCALDNS_INSTALL,
 };
@@ -63,7 +64,7 @@ fn start_paid_tunnel(
     tunnel_manager: &dyn TunnelManager,
     mut state: LocalState,
 ) -> Result<(), CliError> {
-    state = boot.boot_background_services(state.clone())?;
+    state = boot.boot_linkup_server(state.clone())?;
 
     log::info!(
         "Starting paid tunnel with session name: {}",
@@ -110,6 +111,7 @@ fn start_paid_tunnel(
         boot.boot_local_dns(state.domain_strings(), state.linkup.session_name.clone())?;
     }
 
+    print_session_names(&state);
     check_local_not_started(&state)?;
 
     Ok(())
@@ -125,8 +127,37 @@ fn start_free_tunnel(state: LocalState, no_tunnel: bool) -> Result<(), CliError>
     }
 
     let background_service = LocalBackgroundServices {};
-    let state = background_service.boot_background_services(state)?;
+    let mut state = background_service.boot_linkup_server(state)?;
 
+    if state.should_use_tunnel() {
+        let tunnel_manager = CfTunnelManager {};
+        if tunnel_manager.is_tunnel_running().is_err() {
+            println!("Starting tunnel...");
+            let tunnel = tunnel_manager.run_tunnel(&state)?;
+            state.linkup.tunnel = Some(tunnel);
+        } else {
+            println!("Cloudflare tunnel was already running.. Try stopping linkup first if you have problems.");
+        }
+    } else {
+        println!(
+            "Skipping tunnel start... WARNING: not all kinds of requests will work in this mode."
+        );
+    }
+
+    if linkup_file_path(LINKUP_LOCALDNS_INSTALL).exists() {
+        background_service
+            .boot_local_dns(state.domain_strings(), state.linkup.session_name.clone())?;
+    }
+
+    if let Some(tunnel) = &state.linkup.tunnel {
+        println!("Waiting for tunnel DNS to propagate at {}...", tunnel);
+
+        wait_for_dns_ok(tunnel.clone())?;
+
+        println!();
+    }
+
+    print_session_names(&state);
     check_local_not_started(&state)?;
 
     Ok(())
@@ -265,7 +296,7 @@ mod tests {
 
         // Start background services
         mock_boot_bg_services
-            .expect_boot_background_services()
+            .expect_boot_linkup_server()
             .once()
             .returning(|_| Ok(make_state("test_session")));
 
@@ -333,7 +364,7 @@ mod tests {
 
         // Start background services
         mock_boot_bg_services
-            .expect_boot_background_services()
+            .expect_boot_linkup_server()
             .once()
             .returning(|_| Ok(make_state("test_session")));
 
@@ -406,7 +437,7 @@ mod tests {
 
         // Start background services
         mock_boot_bg_services
-            .expect_boot_background_services()
+            .expect_boot_linkup_server()
             .once()
             .returning(|_| Ok(make_state("test_session")));
 
@@ -488,7 +519,7 @@ mod tests {
 
         // Start background services
         mock_boot_bg_services
-            .expect_boot_background_services()
+            .expect_boot_linkup_server()
             .once()
             .returning(|_| Ok(make_state("test_session")));
 


### PR DESCRIPTION
First in a series of PRs to simplify the background booting logic in the cli.

- Remove the `boot_background_services` function in favour of only using more specific ones (`boot_local_dns` etc)
- Moved more of the logic surrounding paid vs free tunnels to the same place
- Some opinionated variable renames