### PR TITLE
feat: size adjustable `status` table

### DIFF
--- a/linkup-cli/src/status.rs
+++ b/linkup-cli/src/status.rs
@@ -238,7 +238,7 @@ pub fn status(json: bool) -> Result<(), CliError> {
             sleep(Duration::from_millis(50));
         }
 
-        stdout.execute(cursor::Show).unwrap();
+        execute!(stdout, cursor::Show, terminal::EnableLineWrap).unwrap();
     }
 
     Ok(())

--- a/linkup-cli/src/status.rs
+++ b/linkup-cli/src/status.rs
@@ -1,5 +1,5 @@
 use colored::{ColoredString, Colorize};
-use crossterm::{cursor, execute, style::Print, terminal, ExecutableCommand};
+use crossterm::{cursor, execute, style::Print, terminal};
 use linkup::{get_additional_headers, HeaderMap, StorableDomain, TargetService};
 use serde::{Deserialize, Serialize};
 use std::{


### PR DESCRIPTION
These changes aim to solve the issue of running status when the terminal window is too small. Now, if the window is <110 the `LOCATION` column will be hidden, and if it is <50 the `COMPONENT KIND` will also be hidden. It will also live update if the window is resized.