### PR TITLE
fix: no session name when starting from scratch

### DIFF
--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -108,8 +108,6 @@ pub enum CliError {
     StopErr(String),
     #[error("could not get status: {0}")]
     StatusErr(String),
-    #[error("your session is in an inconsistent state. Stop your session before trying again.")]
-    InconsistentState,
     #[error("no such service: {0}")]
     NoSuchService(String),
     #[error("failed to install local dns: {0}")]

--- a/linkup-cli/src/start.rs
+++ b/linkup-cli/src/start.rs
@@ -58,9 +58,9 @@ pub async fn start<'a>(args: StartArgs<'_>) -> Result<(), CliError> {
     let status_update_channel = sync::mpsc::channel::<services::RunUpdate>();
 
     let local_server = services::LocalServer::new();
-    let cloudflare_tunnel = services::CloudflareTunnel::new(state.linkup.session_name.clone());
-    let caddy = services::Caddy::new(state.domain_strings());
-    let dnsmasq = services::Dnsmasq::new(state.linkup.session_name.clone(), state.domain_strings());
+    let cloudflare_tunnel = services::CloudflareTunnel::new();
+    let caddy = services::Caddy::new();
+    let dnsmasq = services::Dnsmasq::new();
 
     let mut display_thread: Option<JoinHandle<()>> = None;
     let display_channel = sync::mpsc::channel::<bool>();

--- a/linkup-cli/src/stop.rs
+++ b/linkup-cli/src/stop.rs
@@ -23,13 +23,9 @@ pub fn stop(clear_env: bool) -> Result<(), CliError> {
     }
 
     services::LocalServer::new().stop().unwrap();
-    services::CloudflareTunnel::new(state.linkup.session_name.clone())
-        .stop()
-        .unwrap();
-    services::Caddy::new(state.domain_strings()).stop().unwrap();
-    services::Dnsmasq::new(state.linkup.session_name.clone(), state.domain_strings())
-        .stop()
-        .unwrap();
+    services::CloudflareTunnel::new().stop().unwrap();
+    services::Caddy::new().stop().unwrap();
+    services::Dnsmasq::new().stop().unwrap();
 
     println!("Stopped linkup");
 

--- a/linkup-cli/src/worker_client.rs
+++ b/linkup-cli/src/worker_client.rs
@@ -15,6 +15,8 @@ pub enum Error {
     Serde(#[from] serde_json::Error),
     #[error("request failed with status {0}: {1}")]
     Response(StatusCode, String),
+    #[error("your session is in an inconsistent state. Stop your session before trying again.")]
+    InconsistentState,
 }
 
 pub struct WorkerClient {


### PR DESCRIPTION
This should fix the bug where when starting from a fresh state, Linkup was not setting a session name.

Thanks for the report @jonaslindstr! 💙 