### PR TITLE
feat: add more information on `health`

### DIFF
--- a/linkup-cli/src/services/caddy.rs
+++ b/linkup-cli/src/services/caddy.rs
@@ -164,6 +164,10 @@ impl Caddy {
 
         domains.iter().any(|domain| resolvers.contains(domain))
     }
+
+    pub fn running_pid(&self) -> Option<String> {
+        signal::get_running_pid(&self.pidfile_path)
+    }
 }
 
 impl BackgroundService<Error> for Caddy {
@@ -188,7 +192,7 @@ impl BackgroundService<Error> for Caddy {
 
         self.notify_update(&status_sender, super::RunStatus::Starting);
 
-        if signal::get_running_pid(&self.pidfile_path).is_some() {
+        if self.running_pid().is_some() {
             self.notify_update_with_details(
                 &status_sender,
                 super::RunStatus::Started,
@@ -212,4 +216,16 @@ impl BackgroundService<Error> for Caddy {
 
         Ok(())
     }
+}
+
+pub fn is_installed() -> bool {
+    let res = Command::new("command")
+        .args(["-v", "caddy"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .stdin(Stdio::null())
+        .status()
+        .unwrap();
+
+    res.success()
 }

--- a/linkup-cli/src/services/dnsmasq.rs
+++ b/linkup-cli/src/services/dnsmasq.rs
@@ -84,6 +84,10 @@ pid-file={}\n",
         Ok(())
     }
 
+    pub fn running_pid(&self) -> Option<String> {
+        signal::get_running_pid(&self.pid_file_path)
+    }
+
     fn should_start(&self, domains: &[String]) -> bool {
         let resolvers = local_dns::list_resolvers().unwrap();
 
@@ -113,7 +117,7 @@ impl BackgroundService<Error> for Dnsmasq {
 
         self.notify_update(&status_sender, super::RunStatus::Starting);
 
-        if signal::get_running_pid(&self.pid_file_path).is_some() {
+        if self.running_pid().is_some() {
             self.notify_update_with_details(
                 &status_sender,
                 super::RunStatus::Started,
@@ -147,4 +151,16 @@ impl BackgroundService<Error> for Dnsmasq {
 
         Ok(())
     }
+}
+
+pub fn is_installed() -> bool {
+    let res = Command::new("command")
+        .args(["-v", "dnsmasq"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .stdin(Stdio::null())
+        .status()
+        .unwrap();
+
+    res.success()
 }

--- a/linkup-cli/src/services/local_server.rs
+++ b/linkup-cli/src/services/local_server.rs
@@ -95,6 +95,10 @@ impl LocalServer {
         Ok(())
     }
 
+    pub fn running_pid(&self) -> Option<String> {
+        signal::get_running_pid(&self.pidfile_path)
+    }
+
     async fn reachable(&self) -> bool {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(1))

--- a/linkup-cli/src/services/mod.rs
+++ b/linkup-cli/src/services/mod.rs
@@ -5,10 +5,13 @@ mod cloudflare_tunnel;
 mod dnsmasq;
 mod local_server;
 
-pub use caddy::Caddy;
-pub use cloudflare_tunnel::CloudflareTunnel;
-pub use dnsmasq::Dnsmasq;
 pub use local_server::LocalServer;
+pub use {caddy::is_installed as is_caddy_installed, caddy::Caddy};
+pub use {
+    cloudflare_tunnel::is_installed as is_cloudflared_installed,
+    cloudflare_tunnel::CloudflareTunnel,
+};
+pub use {dnsmasq::is_installed as is_dnsmasq_installed, dnsmasq::Dnsmasq};
 
 use crate::local_config::LocalState;
 


### PR DESCRIPTION
Example of the new background services:
![Screenshot 2024-12-19 at 16 26 25](https://github.com/user-attachments/assets/07fe25d0-d914-4f1b-a06b-48395a666641)


Changelog:
- Add `architecture` to the System information.
- Add Local Linkup server to the list of background services.
- Show on the health if the background service is not installed.
- When the service is running, look at the pid from its pidfile.