### PR TITLE
feat: skip Dnsmasq and Caddy if can't read /etc/resolver

### DIFF
--- a/linkup-cli/src/commands/local_dns.rs
+++ b/linkup-cli/src/commands/local_dns.rs
@@ -146,9 +146,18 @@ fn uninstall_resolvers(resolve_domains: &[String]) -> Result<()> {
     Ok(())
 }
 
-pub fn list_resolvers() -> Result<Vec<String>> {
-    let resolvers = fs::read_dir("/etc/resolver/")?
-        .map(|f| f.unwrap().file_name().into_string().unwrap())
+pub fn list_resolvers() -> std::result::Result<Vec<String>, std::io::Error> {
+    let resolvers_dir = match fs::read_dir("/etc/resolver/") {
+        Ok(read_dir) => read_dir,
+        Err(err) => match err.kind() {
+            std::io::ErrorKind::NotFound => return Ok(vec![]),
+            _ => return Err(err),
+        },
+    };
+
+    let resolvers = resolvers_dir
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| entry.file_name().into_string().ok())
         .collect();
 
     Ok(resolvers)

--- a/linkup-cli/src/services/caddy.rs
+++ b/linkup-cli/src/services/caddy.rs
@@ -159,10 +159,10 @@ impl Caddy {
         output_str.contains("redis")
     }
 
-    fn should_start(&self, domains: &[String]) -> bool {
-        let resolvers = local_dns::list_resolvers().unwrap();
+    fn should_start(&self, domains: &[String]) -> Result<bool, Error> {
+        let resolvers = local_dns::list_resolvers()?;
 
-        domains.iter().any(|domain| resolvers.contains(domain))
+        Ok(domains.iter().any(|domain| resolvers.contains(domain)))
     }
 
     pub fn running_pid(&self) -> Option<String> {
@@ -180,14 +180,28 @@ impl BackgroundService<Error> for Caddy {
     ) -> Result<(), Error> {
         let domains = &state.domain_strings();
 
-        if !self.should_start(domains) {
-            self.notify_update_with_details(
-                &status_sender,
-                super::RunStatus::Skipped,
-                "Local DNS not installed",
-            );
+        match self.should_start(domains) {
+            Ok(true) => (),
+            Ok(false) => {
+                self.notify_update_with_details(
+                    &status_sender,
+                    super::RunStatus::Skipped,
+                    "Local DNS not installed",
+                );
 
-            return Ok(());
+                return Ok(());
+            }
+            Err(err) => {
+                self.notify_update_with_details(
+                    &status_sender,
+                    super::RunStatus::Skipped,
+                    "Failed to read resolvers folder",
+                );
+
+                log::warn!("Failed to read resolvers folder: {}", err);
+
+                return Ok(());
+            }
         }
 
         self.notify_update(&status_sender, super::RunStatus::Starting);

--- a/linkup-cli/src/services/dnsmasq.rs
+++ b/linkup-cli/src/services/dnsmasq.rs
@@ -90,10 +90,10 @@ pid-file={}\n",
         signal::get_running_pid(&self.pid_file_path)
     }
 
-    fn should_start(&self, domains: &[String]) -> bool {
-        let resolvers = local_dns::list_resolvers().unwrap();
+    fn should_start(&self, domains: &[String]) -> Result<bool, Error> {
+        let resolvers = local_dns::list_resolvers()?;
 
-        domains.iter().any(|domain| resolvers.contains(domain))
+        Ok(domains.iter().any(|domain| resolvers.contains(domain)))
     }
 }
 
@@ -107,14 +107,28 @@ impl BackgroundService<Error> for Dnsmasq {
     ) -> Result<(), Error> {
         let domains = &state.domain_strings();
 
-        if !self.should_start(domains) {
-            self.notify_update_with_details(
-                &status_sender,
-                super::RunStatus::Skipped,
-                "Local DNS not installed",
-            );
+        match self.should_start(domains) {
+            Ok(true) => (),
+            Ok(false) => {
+                self.notify_update_with_details(
+                    &status_sender,
+                    super::RunStatus::Skipped,
+                    "Local DNS not installed",
+                );
 
-            return Ok(());
+                return Ok(());
+            }
+            Err(err) => {
+                self.notify_update_with_details(
+                    &status_sender,
+                    super::RunStatus::Skipped,
+                    "Failed to read resolvers folder",
+                );
+
+                log::warn!("Failed to read resolvers folder: {}", err);
+
+                return Ok(());
+            }
         }
 
         self.notify_update(&status_sender, super::RunStatus::Starting);


### PR DESCRIPTION
This should fix cases where starting Linkup on a system that does not have `/etc/resolver` setup would break.
Now it will skip both `caddy` and `dnsmasq` if the folder is not found.