### PR TITLE
feat: enable logs to all commands and store in file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -480,6 +480,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -559,6 +568,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,29 +625,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
 ]
 
 [[package]]
@@ -976,12 +971,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,7 +1262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1320,13 +1309,11 @@ dependencies = [
  "colored",
  "crossterm",
  "ctrlc",
- "env_logger",
  "flate2",
  "hex",
  "hickory-resolver",
  "linkup",
  "linkup-local-server",
- "log",
  "mockall",
  "nix",
  "rand",
@@ -1340,6 +1327,9 @@ dependencies = [
  "tar",
  "thiserror 2.0.11",
  "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -1436,6 +1426,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "matchit"
@@ -1556,6 +1555,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,6 +1599,12 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1651,6 +1672,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1849,8 +1876,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1861,8 +1897,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2242,6 +2284,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2429,6 +2480,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,6 +2682,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2607,6 +2711,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2698,6 +2832,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -15,7 +15,6 @@ ctrlc = { version = "3.4.5", features = ["termination"] }
 hickory-resolver = { version = "0.24.2", features = ["tokio-runtime"] }
 linkup = { path = "../linkup" }
 linkup-local-server = { path = "../local-server" }
-log = "0.4.25"
 nix = { version = "0.29.0", features = ["signal"] }
 rand = "0.8.5"
 regex = "1.11.1"
@@ -31,9 +30,11 @@ serde_json = "1.0.137"
 serde_yaml = "0.9.34"
 tokio = { version = "1.43.0", features = ["macros"] }
 thiserror = "2.0.11"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
+tracing-appender = { version = "0.2" }
 url = { version = "2.5.4", features = ["serde"] }
 base64 = "0.22.1"
-env_logger = "0.11.6"
 crossterm = "0.28.1"
 sysinfo = "0.33.1"
 sha2 = "0.10.8"

--- a/linkup-cli/src/commands/health.rs
+++ b/linkup-cli/src/commands/health.rs
@@ -199,7 +199,7 @@ impl Health {
             Ok(session) => Some(session),
             Err(CliError::NoState(_)) => None,
             Err(error) => {
-                log::error!("Failed to load Session: {}", error);
+                tracing::error!("Failed to load Session: {}", error);
                 None
             }
         };

--- a/linkup-cli/src/commands/start.rs
+++ b/linkup-cli/src/commands/start.rs
@@ -36,8 +36,6 @@ pub async fn start(
     fresh_state: bool,
     config_arg: &Option<String>,
 ) -> Result<(), CliError> {
-    env_logger::init();
-
     let mut state = if fresh_state {
         let state = load_and_save_state(config_arg, args.no_tunnel)?;
         set_linkup_env(state.clone())?;

--- a/linkup-cli/src/commands/stop.rs
+++ b/linkup-cli/src/commands/stop.rs
@@ -25,7 +25,7 @@ pub fn stop(_args: &Args, clear_env: bool) -> Result<(), CliError> {
         }
         (Ok(_), false) => (),
         (Err(err), _) => {
-            log::warn!("Failed to fetch local state: {}", err);
+            tracing::warn!("Failed to fetch local state: {}", err);
         }
     }
 

--- a/linkup-cli/src/commands/uninstall.rs
+++ b/linkup-cli/src/commands/uninstall.rs
@@ -10,16 +10,16 @@ pub fn uninstall(_args: &Args) -> Result<(), CliError> {
 
     let linkup_dir = linkup_dir_path();
 
-    log::debug!("Removing linkup folder: {}", linkup_dir.display());
+    tracing::debug!("Removing linkup folder: {}", linkup_dir.display());
     fs::remove_dir_all(linkup_dir)?;
 
     let exe_path = fs::canonicalize(std::env::current_exe()?)?
         .display()
         .to_string();
 
-    log::debug!("Linkup exe path: {}", &exe_path);
+    tracing::debug!("Linkup exe path: {}", &exe_path);
     if exe_path.contains("homebrew") {
-        log::debug!("Uninstalling linkup from Homebrew");
+        tracing::debug!("Uninstalling linkup from Homebrew");
 
         process::Command::new("brew")
             .args(["uninstall", "linkup"])
@@ -28,7 +28,7 @@ pub fn uninstall(_args: &Args) -> Result<(), CliError> {
             .stderr(process::Stdio::null())
             .status()?;
     } else if exe_path.contains(".cargo") {
-        log::debug!("Uninstalling linkup from Cargo");
+        tracing::debug!("Uninstalling linkup from Cargo");
 
         process::Command::new("cargo")
             .args(["uninstall", "linkup-cli"])

--- a/linkup-cli/src/commands/update.rs
+++ b/linkup-cli/src/commands/update.rs
@@ -198,7 +198,7 @@ async fn available_update() -> Option<Asset> {
     let current_version = match Version::try_from(CURRENT_VERSION) {
         Ok(version) => version,
         Err(error) => {
-            log::error!(
+            tracing::error!(
                 "Failed to parse current version '{}': {}",
                 CURRENT_VERSION,
                 error
@@ -214,7 +214,7 @@ async fn available_update() -> Option<Asset> {
             let release = match fetch_latest_release().await {
                 Ok(release) => release,
                 Err(error) => {
-                    log::error!("Failed to fetch the latest release: {}", error);
+                    tracing::error!("Failed to fetch the latest release: {}", error);
 
                     return None;
                 }
@@ -223,13 +223,13 @@ async fn available_update() -> Option<Asset> {
             match fs::File::create(linkup_file_path(CACHED_LATEST_RELEASE_FILE)) {
                 Ok(new_file) => {
                     if let Err(error) = serde_json::to_writer_pretty(new_file, &release) {
-                        log::error!("Failed to write the release data into cache: {}", error);
+                        tracing::error!("Failed to write the release data into cache: {}", error);
                     }
 
                     release
                 }
                 Err(error) => {
-                    log::error!("Failed to create release cache file: {}", error);
+                    tracing::error!("Failed to create release cache file: {}", error);
 
                     release
                 }
@@ -240,7 +240,7 @@ async fn available_update() -> Option<Asset> {
     let latest_version = match Version::try_from(latest_release.version.as_str()) {
         Ok(version) => version,
         Err(error) => {
-            log::error!(
+            tracing::error!(
                 "Failed to parse latest version '{}': {}",
                 latest_release.version,
                 error
@@ -291,7 +291,7 @@ async fn cached_latest_release() -> Option<CachedLatestRelease> {
     let file = match fs::File::open(&path) {
         Ok(file) => file,
         Err(error) => {
-            log::error!("Failed to open cached latest release file: {}", error);
+            tracing::error!("Failed to open cached latest release file: {}", error);
 
             return None;
         }
@@ -300,7 +300,7 @@ async fn cached_latest_release() -> Option<CachedLatestRelease> {
     let cached_latest_release: CachedLatestRelease = match serde_json::from_reader(file) {
         Ok(cached_latest_release) => cached_latest_release,
         Err(error) => {
-            log::error!("Failed to parse cached latest release: {}", error);
+            tracing::error!("Failed to parse cached latest release: {}", error);
             return None;
         }
     };
@@ -310,7 +310,7 @@ async fn cached_latest_release() -> Option<CachedLatestRelease> {
 
     if time_now - cache_time > Duration::from_secs(60 * 60 * 24) {
         if let Err(error) = fs::remove_file(&path) {
-            log::error!("Failed to delete cached latest release file: {}", error);
+            tracing::error!("Failed to delete cached latest release file: {}", error);
         }
 
         return None;

--- a/linkup-cli/src/local_config.rs
+++ b/linkup-cli/src/local_config.rs
@@ -312,7 +312,7 @@ pub async fn upload_state(state: &LocalState) -> Result<String, worker_client::E
         upload_config_to_server(&local_url, &server_session_name, server_config.local).await?;
 
     if server_session_name != local_session_name {
-        log::error!(
+        tracing::error!(
             "Local session has name: {} and remote has name: {}",
             &local_session_name,
             &server_session_name

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -1,4 +1,10 @@
-use std::{env, fs, io::ErrorKind, path::PathBuf, process};
+use std::{
+    env,
+    fs::{self},
+    io::ErrorKind,
+    path::PathBuf,
+    process,
+};
 
 use clap::{Parser, Subcommand};
 use colored::Colorize;
@@ -225,7 +231,15 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    env_logger::init();
+    let file_appender =
+        tracing_appender::rolling::daily(linkup_file_path("logs"), "linkup-cli.log");
+    let (writer, _guard) = tracing_appender::non_blocking(file_appender);
+
+    tracing_subscriber::fmt()
+        .with_writer(writer)
+        .with_env_filter(tracing_subscriber::filter::EnvFilter::from_default_env())
+        .with_ansi(false)
+        .init();
 
     let cli = Cli::parse();
 

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -225,6 +225,8 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    env_logger::init();
+
     let cli = Cli::parse();
 
     ensure_linkup_dir()?;

--- a/linkup-cli/src/services/caddy.rs
+++ b/linkup-cli/src/services/caddy.rs
@@ -63,7 +63,7 @@ impl Caddy {
     }
 
     fn start(&self, domains: &[String]) -> Result<(), Error> {
-        log::debug!("Starting {}", Self::NAME);
+        tracing::debug!("Starting {}", Self::NAME);
 
         if std::env::var(LINKUP_CF_TLS_API_ENV_VAR).is_err() {
             return Err(Error::MissingTlsApiTokenEnv);
@@ -115,7 +115,7 @@ impl Caddy {
     }
 
     pub fn stop(&self) -> Result<(), Error> {
-        log::debug!("Stopping {}", Self::NAME);
+        tracing::debug!("Stopping {}", Self::NAME);
 
         signal::stop_pid_file(&self.pidfile_path, signal::Signal::SIGTERM)?;
 
@@ -226,7 +226,7 @@ impl BackgroundService<Error> for Caddy {
                     "Failed to read resolvers folder",
                 );
 
-                log::warn!("Failed to read resolvers folder: {}", err);
+                tracing::warn!("Failed to read resolvers folder: {}", err);
 
                 return Ok(());
             }

--- a/linkup-cli/src/services/cloudflare_tunnel/paid_tunnel.rs
+++ b/linkup-cli/src/services/cloudflare_tunnel/paid_tunnel.rs
@@ -285,7 +285,7 @@ fn create_config_yml(sys: &dyn System, tunnel_id: &str) -> Result<(), CliError> 
 
     // Create the directory if it does not exist
     if !sys.file_exists(dir_path.as_path()) {
-        log::info!("Creating directory: {:?}", dir_path);
+        tracing::info!("Creating directory: {:?}", dir_path);
         sys.create_dir_all(&dir_path).map_err(|err| {
             CliError::FileErr("Could not create directory".to_string(), err.to_string())
         })?;

--- a/linkup-cli/src/services/dnsmasq.rs
+++ b/linkup-cli/src/services/dnsmasq.rs
@@ -64,7 +64,7 @@ pid-file={}\n",
     }
 
     fn start(&self) -> Result<(), Error> {
-        log::debug!("Starting {}", Self::NAME);
+        tracing::debug!("Starting {}", Self::NAME);
 
         Command::new("dnsmasq")
             .current_dir(linkup_dir_path())
@@ -79,7 +79,7 @@ pid-file={}\n",
     }
 
     pub fn stop(&self) -> Result<(), Error> {
-        log::debug!("Stopping {}", Self::NAME);
+        tracing::debug!("Stopping {}", Self::NAME);
 
         signal::stop_pid_file(&self.pid_file_path, signal::Signal::SIGTERM)?;
 
@@ -125,7 +125,7 @@ impl BackgroundService<Error> for Dnsmasq {
                     "Failed to read resolvers folder",
                 );
 
-                log::warn!("Failed to read resolvers folder: {}", err);
+                tracing::warn!("Failed to read resolvers folder: {}", err);
 
                 return Ok(());
             }

--- a/linkup-cli/src/services/local_server.rs
+++ b/linkup-cli/src/services/local_server.rs
@@ -54,7 +54,7 @@ impl LocalServer {
     }
 
     fn start(&self) -> Result<(), Error> {
-        log::debug!("Starting {}", Self::NAME);
+        tracing::debug!("Starting {}", Self::NAME);
 
         let stdout_file = File::create(&self.stdout_file_path)?;
         let stderr_file = File::create(&self.stderr_file_path)?;
@@ -89,7 +89,7 @@ impl LocalServer {
     }
 
     pub fn stop(&self) -> Result<(), Error> {
-        log::debug!("Stopping {}", Self::NAME);
+        tracing::debug!("Stopping {}", Self::NAME);
         signal::stop_pid_file(&self.pidfile_path, signal::Signal::SIGINT)?;
 
         Ok(())


### PR DESCRIPTION
This change makes it so that logging works on all commands. Currently it only works on the `start` command.
On this PR it also changes from using `log` to using `tracing`. With this, we can stream the logs into files inside the `./linkup/logs` folder.