### PR TITLE
fix: latest release cache file format

### DIFF
--- a/linkup-cli/src/commands/update.rs
+++ b/linkup-cli/src/commands/update.rs
@@ -222,11 +222,16 @@ async fn available_update() -> Option<Asset> {
 
             match fs::File::create(linkup_file_path(CACHED_LATEST_RELEASE_FILE)) {
                 Ok(new_file) => {
-                    if let Err(error) = serde_json::to_writer_pretty(new_file, &release) {
+                    let release_cache = CachedLatestRelease {
+                        time: now(),
+                        release,
+                    };
+
+                    if let Err(error) = serde_json::to_writer_pretty(new_file, &release_cache) {
                         log::error!("Failed to write the release data into cache: {}", error);
                     }
 
-                    release
+                    release_cache.release
                 }
                 Err(error) => {
                     log::error!("Failed to create release cache file: {}", error);
@@ -301,6 +306,12 @@ async fn cached_latest_release() -> Option<CachedLatestRelease> {
         Ok(cached_latest_release) => cached_latest_release,
         Err(error) => {
             log::error!("Failed to parse cached latest release: {}", error);
+
+            // Since we can't parse this file. We remove it.
+            if fs::remove_file(&path).is_err() {
+                log::error!("Failed to delete latest release cache file");
+            }
+
             return None;
         }
     };


### PR DESCRIPTION
We are storing the format different than the one that we are trying to read, so this is not working. This should fix the issue by storing the expected `CachedLatestRelease`.