### PR TITLE
feat: move worker token to config instead of env

### DIFF
--- a/linkup-cli/src/commands/health.rs
+++ b/linkup-cli/src/commands/health.rs
@@ -72,19 +72,6 @@ impl Session {
 }
 
 #[derive(Debug, Serialize)]
-struct EnvironmentVariables {
-    linkup_worker_token: bool,
-}
-
-impl EnvironmentVariables {
-    fn load() -> Self {
-        Self {
-            linkup_worker_token: env::var("LINKUP_WORKER_TOKEN").is_ok(),
-        }
-    }
-}
-
-#[derive(Debug, Serialize)]
 struct BackgroudServices {
     linkup_server: BackgroundServiceHealth,
     caddy: BackgroundServiceHealth,
@@ -183,7 +170,6 @@ impl LocalDNS {
 struct Health {
     system: System,
     session: Option<Session>,
-    environment_variables: EnvironmentVariables,
     background_services: BackgroudServices,
     linkup: Linkup,
     local_dns: LocalDNS,
@@ -203,7 +189,6 @@ impl Health {
         Ok(Self {
             system: System::load(),
             session,
-            environment_variables: EnvironmentVariables::load(),
             background_services: BackgroudServices::load(),
             linkup: Linkup::load()?,
             local_dns: LocalDNS::load()?,
@@ -261,15 +246,6 @@ impl Display for Health {
             BackgroundServiceHealth::NotInstalled => writeln!(f, "{}", "NOT INSTALLED".yellow())?,
             BackgroundServiceHealth::Stopped => writeln!(f, "{}", "NOT RUNNING".yellow())?,
             BackgroundServiceHealth::Running(pid) => writeln!(f, "{} ({})", "RUNNING".blue(), pid)?,
-        }
-
-        writeln!(f, "{}", "Environment variables:".bold().italic())?;
-
-        write!(f, "  - LINKUP_WORKER_TOKEN   ")?;
-        if self.environment_variables.linkup_worker_token {
-            writeln!(f, "{}", "OK".blue())?;
-        } else {
-            writeln!(f, "{}", "MISSING".yellow())?;
         }
 
         writeln!(f, "{}", "Linkup:".bold().italic())?;

--- a/linkup-cli/src/local_config.rs
+++ b/linkup-cli/src/local_config.rs
@@ -400,6 +400,7 @@ mod tests {
     const CONF_STR: &str = r#"
 linkup:
   remote: https://remote-linkup.example.com
+  worker_token: test_token_123
 services:
   - name: frontend
     remote: http://remote-service1.example.com
@@ -437,6 +438,10 @@ domains:
         assert_eq!(
             local_state.linkup.remote,
             Url::parse("https://remote-linkup.example.com").unwrap()
+        );
+        assert_eq!(
+            local_state.linkup.worker_token,
+            String::from("test_token_123"),
         );
 
         assert_eq!(local_state.services.len(), 2);

--- a/linkup-cli/src/local_config.rs
+++ b/linkup-cli/src/local_config.rs
@@ -93,6 +93,7 @@ impl LocalState {
 pub struct LinkupState {
     pub session_name: String,
     pub session_token: String,
+    pub worker_token: String,
     pub config_path: String,
     pub remote: Url,
     pub tunnel: Option<Url>,
@@ -179,6 +180,7 @@ impl YamlLocalConfig {
 #[derive(Deserialize, Clone)]
 pub struct LinkupConfig {
     pub remote: Url,
+    pub worker_token: String,
     cache_routes: Option<Vec<String>>,
 }
 
@@ -218,6 +220,7 @@ pub fn config_to_state(
         is_paid: Some(is_paid),
         session_name: String::new(),
         session_token: random_token,
+        worker_token: yaml_config.linkup.worker_token,
         config_path,
         remote: yaml_config.linkup.remote,
         tunnel,


### PR DESCRIPTION
With this change, the config file will need a new required field: `worker_token`. This should be the token to be sent to the linkup.remote (worker) when making requests.

Closes DO-1928