### PR TITLE
fix: ensure only dashes on worker name

### DIFF
--- a/linkup-cli/src/commands/deploy/resources.rs
+++ b/linkup-cli/src/commands/deploy/resources.rs
@@ -840,7 +840,7 @@ pub fn cf_resources(
     all_zone_names: &[String],
     all_zone_ids: &[String],
 ) -> TargetCfResources {
-    let joined_zone_names = all_zone_names.join("-");
+    let joined_zone_names = all_zone_names.join("-").replace(".", "-");
     let linkup_script_name = format!("linkup-worker-{joined_zone_names}");
 
     TargetCfResources {


### PR DESCRIPTION
> Invalid Worker name. Ensure the name is lowercase, alphanumeric, and contains no spaces or special characters except dashes.

😬