### PR TITLE
feat: add authentication to `/linkup/certificate*` endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,6 +1534,7 @@ dependencies = [
  "linkup-local-server",
  "log",
  "mockall",
+ "mockito",
  "nix",
  "rand",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,6 +1522,7 @@ dependencies = [
  "base64",
  "clap",
  "clap_complete",
+ "cloudflare",
  "colored 3.0.0",
  "crossterm",
  "ctrlc",

--- a/cloudflare/src/endpoints/workers/mod.rs
+++ b/cloudflare/src/endpoints/workers/mod.rs
@@ -88,7 +88,17 @@ impl ApiResult for Vec<WorkersTail> {}
 pub struct WorkersBinding {
     pub name: String,
     pub r#type: String,
-    pub namespace_id: String,
+    // Namespace is not guarantee to exist on all bindings. It exists for type `kv_namespace`, but not for `plain_text`, for example.
+    // This should probably be an enum over the possible types of bindings. Something like what we did on deploy/api.rs:
+    //
+    // #[derive(Debug, Clone)]
+    // pub enum WorkerBinding {
+    //    KvNamespace { name: String, namespace_id: String },
+    //    PlainText { name: String, text: String },
+    //    SecretText { name: String, text: String },
+    // }
+    //
+    // pub namespace_id: String,
     pub class_name: Option<String>,
 }
 

--- a/cloudflare/src/framework/response/mod.rs
+++ b/cloudflare/src/framework/response/mod.rs
@@ -1,10 +1,10 @@
 mod apifail;
 
 pub use apifail::*;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::value::Value as JsonValue;
 
-#[derive(Deserialize, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct ApiSuccess<ResultType> {
     pub result: ResultType,
     pub result_info: Option<JsonValue>,

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -41,8 +41,8 @@ sha2 = "0.10.8"
 hex = "0.4.3"
 tar = "0.4.43"
 flate2 = "1.0.35"
-# NOTE(augustoccesar)[2025-02-19]: This old version is to match the one being used by cloudflare
-mockito = "0.31"
 
 [dev-dependencies]
 mockall = "0.13.1"
+# NOTE(augustoccesar)[2025-02-19]: This old version is to match the one being used by cloudflare
+mockito = "0.31"

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5.27", features = ["derive", "cargo"] }
 clap_complete = "4.5.42"
+cloudflare = { path = "../cloudflare" }
 colored = "3.0.0"
 ctrlc = { version = "3.4.5", features = ["termination"] }
 hickory-resolver = { version = "0.24.2", features = ["tokio-runtime"] }

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5.27", features = ["derive", "cargo"] }
 clap_complete = "4.5.42"
-cloudflare = { path = "../cloudflare" }
+cloudflare = { path = "../cloudflare", features = ["mockito"] }
 colored = "3.0.0"
 ctrlc = { version = "3.4.5", features = ["termination"] }
 hickory-resolver = { version = "0.24.2", features = ["tokio-runtime"] }
@@ -41,6 +41,8 @@ sha2 = "0.10.8"
 hex = "0.4.3"
 tar = "0.4.43"
 flate2 = "1.0.35"
+# NOTE(augustoccesar)[2025-02-19]: This old version is to match the one being used by cloudflare
+mockito = "0.31"
 
 [dev-dependencies]
 mockall = "0.13.1"

--- a/linkup-cli/src/commands/deploy/cf_deploy.rs
+++ b/linkup-cli/src/commands/deploy/cf_deploy.rs
@@ -446,176 +446,186 @@ export default {
         }
     }
 
-    // TODO(augustoccesar)[2025-02-19]: Fix tests to support Cloudflare client
-
-    // #[tokio::test]
-    // async fn test_deploy_to_cloudflare_creates_script_when_none_exists() {
-    //     let api = TestCloudflareApi::new(vec!["test-zone-id".to_string()]);
-
-    //     let notifier = TestNotifier {
-    //         messages: RefCell::new(vec![]),
-    //         confirmation_response: true,
-    //         confirmations_asked: RefCell::new(0),
-    //     };
-
-    //     // Call deploy_to_cloudflare directly
-    //     let result = deploy_to_cloudflare(&test_resources(), &api, &notifier).await;
-    //     assert!(result.is_ok());
-
-    //     // Check that a worker script was created
-    //     let created = api.create_called_with.borrow();
-    //     let (script_name, metadata, parts) = created.as_ref().unwrap();
-
-    //     assert_eq!(script_name, "linkup-integration-test-script");
-    //     assert_eq!(metadata.main_module, "index.js");
-    //     assert_eq!(metadata.bindings.len(), 3);
-    //     assert_eq!(metadata.compatibility_date, "2024-12-18");
-
-    //     assert_eq!(parts.len(), 1);
-    //     assert_eq!(parts[0].name, "index.js");
-    //     assert_eq!(
-    //         String::from_utf8(parts[0].data.clone()).unwrap(),
-    //         LOCAL_SCRIPT_CONTENT
-    //     );
-    // }
-
-    // #[tokio::test]
-    // async fn test_deploy_to_cloudflare_creates_script_when_content_differs() {
-    //     let api = TestCloudflareApi::new(vec!["test-zone-id".to_string()]);
-
-    //     let notifier = TestNotifier {
-    //         messages: RefCell::new(vec![]),
-    //         confirmation_response: true,
-    //         confirmations_asked: RefCell::new(0),
-    //     };
-
-    //     let result = deploy_to_cloudflare(&test_resources(), &api, &notifier).await;
-    //     assert!(result.is_ok());
-
-    //     assert_eq!(*notifier.confirmations_asked.borrow(), 1);
-
-    //     let created = api.create_called_with.borrow();
-    //     let (script_name, metadata, parts) = created.as_ref().unwrap();
-
-    //     assert_eq!(script_name, "linkup-integration-test-script");
-    //     assert_eq!(metadata.main_module, "index.js");
-    //     assert_eq!(metadata.bindings.len(), 3);
-    //     assert_eq!(metadata.compatibility_date, "2024-12-18");
-
-    //     assert_eq!(parts.len(), 1);
-    //     assert_eq!(parts[0].name, "index.js");
-    //     assert_eq!(
-    //         String::from_utf8(parts[0].data.clone()).unwrap(),
-    //         LOCAL_SCRIPT_CONTENT
-    //     );
-    // }
-
-    // #[tokio::test]
-    // async fn test_deploy_to_cloudflare_canceled_by_user() {
-    //     let api = TestCloudflareApi::new(vec!["test-zone-id".to_string()]);
-
-    //     let notifier = TestNotifier {
-    //         messages: RefCell::new(vec![]),
-    //         confirmation_response: false,
-    //         confirmations_asked: RefCell::new(0),
-    //     };
-
-    //     let result = deploy_to_cloudflare(&test_resources(), &api, &notifier).await;
-    //     assert!(result.is_ok());
-
-    //     assert_eq!(*notifier.confirmations_asked.borrow(), 1);
-
-    //     let created = api.create_called_with.borrow();
-    //     assert!(created.is_none());
-    // }
-
-    // #[tokio::test]
-    // async fn test_deploy_creates_dns_and_route_if_not_exist() {
-    //     let api = TestCloudflareApi::new(vec!["test-zone-id".to_string()]);
-
-    //     let notifier = TestNotifier {
-    //         messages: RefCell::new(vec![]),
-    //         confirmation_response: true,
-    //         confirmations_asked: RefCell::new(0),
-    //     };
-
-    //     let res = test_resources();
-
-    //     // Call deploy_to_cloudflare directly
-    //     let result = deploy_to_cloudflare(&res, &api, &notifier).await;
-    //     assert!(result.is_ok());
-
-    //     // Check DNS record created
-    //     let dns_records = api.dns_records.borrow();
-    //     assert_eq!(dns_records.len(), 1);
-    //     assert_eq!(dns_records[0].name, "linkup-integration-test");
-    //     assert!(dns_records[0]
-    //         .content
-    //         .contains("linkup-integration-test-script.workers.dev"));
-
-    //     // Check route created
-    //     let routes = api.worker_routes.borrow();
-    //     assert_eq!(routes.len(), 1);
-    //     assert_eq!(routes[0].1, "linkup-integration-test.example.com/*");
-    //     assert_eq!(routes[0].2, "linkup-integration-test-script");
-    // }
-
-    // #[tokio::test]
-    // async fn test_deploy_creates_account_token() {
-    //     let api = TestCloudflareApi::new(vec!["test-zone-id".to_string()]);
-
-    //     let notifier = TestNotifier {
-    //         messages: RefCell::new(vec![]),
-    //         confirmation_response: true,
-    //         confirmations_asked: RefCell::new(0),
-    //     };
-
-    //     let res = test_resources();
-
-    //     // Call deploy_to_cloudflare directly
-    //     let result = deploy_to_cloudflare(&res, &api, &notifier).await;
-    //     assert!(result.is_ok());
-
-    //     let tokens = api.account_tokens.borrow();
-    //     assert_eq!(tokens.len(), 1);
-    //     assert_eq!(tokens[0].0, "created".to_string());
-    //     assert_eq!(tokens[0].1, LINKUP_ACCOUNT_TOKEN_NAME.to_string());
-    // }
-
-    // #[tokio::test]
-    // async fn test_deploy_skips_creating_account_token_if_already_exists() {
-    //     let api = TestCloudflareApi::new(vec!["test-zone-id".to_string()]);
-    //     api.account_tokens.borrow_mut().push((
-    //         "existing".to_string(),
-    //         LINKUP_ACCOUNT_TOKEN_NAME.to_string(),
-    //     ));
-
-    //     let notifier = TestNotifier {
-    //         messages: RefCell::new(vec![]),
-    //         confirmation_response: true,
-    //         confirmations_asked: RefCell::new(0),
-    //     };
-
-    //     let res = test_resources();
-
-    //     // Call deploy_to_cloudflare directly
-    //     let result = deploy_to_cloudflare(&res, &api, &notifier).await;
-    //     assert!(result.is_ok());
-
-    //     let tokens = api.account_tokens.borrow();
-    //     assert_eq!(tokens.len(), 1);
-    //     assert_eq!(tokens[0].0, "existing".to_string());
-    //     assert_eq!(tokens[0].1, LINKUP_ACCOUNT_TOKEN_NAME.to_string());
-    // }
-
     #[tokio::test]
-    async fn test_deploy_and_destroy_real_integration() {
+    async fn test_deploy_to_cloudflare_creates_script_when_none_exists() {
+        let api = TestCloudflareApi::new(vec!["test-zone-id".to_string()]);
+
         let notifier = TestNotifier {
             messages: RefCell::new(vec![]),
             confirmation_response: true,
             confirmations_asked: RefCell::new(0),
         };
 
+        let resources = test_resources();
+        let _mocks = mock_cloudflare_endpoints(&resources);
+
+        // Call deploy_to_cloudflare directly
+        let result =
+            deploy_to_cloudflare(&resources, &api, &cloudflare_test_client(), &notifier).await;
+        assert!(result.is_ok());
+
+        // Check that a worker script was created
+        let created = api.create_called_with.borrow();
+        let (script_name, metadata, parts) = created.as_ref().unwrap();
+
+        assert_eq!(script_name, "linkup-integration-test-script");
+        assert_eq!(metadata.main_module, "index.js");
+        assert_eq!(metadata.bindings.len(), 4);
+        assert_eq!(metadata.compatibility_date, "2024-12-18");
+
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0].name, "index.js");
+        assert_eq!(
+            String::from_utf8(parts[0].data.clone()).unwrap(),
+            LOCAL_SCRIPT_CONTENT
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deploy_to_cloudflare_creates_script_when_content_differs() {
+        let api = TestCloudflareApi::new(vec!["test-zone-id".to_string()]);
+
+        let notifier = TestNotifier {
+            messages: RefCell::new(vec![]),
+            confirmation_response: true,
+            confirmations_asked: RefCell::new(0),
+        };
+
+        let resources = test_resources();
+        let _mocks = mock_cloudflare_endpoints(&resources);
+
+        let result =
+            deploy_to_cloudflare(&resources, &api, &cloudflare_test_client(), &notifier).await;
+        assert!(result.is_ok());
+
+        assert_eq!(*notifier.confirmations_asked.borrow(), 1);
+
+        let created = api.create_called_with.borrow();
+        let (script_name, metadata, parts) = created.as_ref().unwrap();
+
+        assert_eq!(script_name, "linkup-integration-test-script");
+        assert_eq!(metadata.main_module, "index.js");
+        assert_eq!(metadata.bindings.len(), 4);
+        assert_eq!(metadata.compatibility_date, "2024-12-18");
+
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0].name, "index.js");
+        assert_eq!(
+            String::from_utf8(parts[0].data.clone()).unwrap(),
+            LOCAL_SCRIPT_CONTENT
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deploy_to_cloudflare_canceled_by_user() {
+        let api = TestCloudflareApi::new(vec!["test-zone-id".to_string()]);
+
+        let notifier = TestNotifier {
+            messages: RefCell::new(vec![]),
+            confirmation_response: false,
+            confirmations_asked: RefCell::new(0),
+        };
+
+        let resources = test_resources();
+        let _mocks = mock_cloudflare_endpoints(&resources);
+
+        let result =
+            deploy_to_cloudflare(&resources, &api, &cloudflare_test_client(), &notifier).await;
+        assert!(result.is_ok());
+
+        assert_eq!(*notifier.confirmations_asked.borrow(), 1);
+
+        let created = api.create_called_with.borrow();
+        assert!(created.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_deploy_creates_dns_and_route_if_not_exist() {
+        let api = TestCloudflareApi::new(vec!["test-zone-id".to_string()]);
+
+        let notifier = TestNotifier {
+            messages: RefCell::new(vec![]),
+            confirmation_response: true,
+            confirmations_asked: RefCell::new(0),
+        };
+
+        let resources = test_resources();
+        let _mocks = mock_cloudflare_endpoints(&resources);
+
+        // Call deploy_to_cloudflare directly
+        let result =
+            deploy_to_cloudflare(&resources, &api, &cloudflare_test_client(), &notifier).await;
+        assert!(result.is_ok());
+
+        // Check DNS record created
+        let dns_records = api.dns_records.borrow();
+        assert_eq!(dns_records.len(), 1);
+        assert_eq!(dns_records[0].name, "linkup-integration-test");
+        assert!(dns_records[0]
+            .content
+            .contains("linkup-integration-test-script.workers.dev"));
+
+        // Check route created
+        let routes = api.worker_routes.borrow();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].1, "linkup-integration-test.example.com/*");
+        assert_eq!(routes[0].2, "linkup-integration-test-script");
+    }
+
+    #[tokio::test]
+    async fn test_deploy_creates_account_token() {
+        let api = TestCloudflareApi::new(vec!["test-zone-id".to_string()]);
+
+        let notifier = TestNotifier {
+            messages: RefCell::new(vec![]),
+            confirmation_response: true,
+            confirmations_asked: RefCell::new(0),
+        };
+
+        let resources = test_resources();
+        let _mocks = mock_cloudflare_endpoints(&resources);
+
+        // Call deploy_to_cloudflare directly
+        let result =
+            deploy_to_cloudflare(&resources, &api, &cloudflare_test_client(), &notifier).await;
+        assert!(result.is_ok());
+
+        let tokens = api.account_tokens.borrow();
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0].0, "created".to_string());
+        assert_eq!(tokens[0].1, LINKUP_ACCOUNT_TOKEN_NAME.to_string());
+    }
+
+    #[tokio::test]
+    async fn test_deploy_skips_creating_account_token_if_already_exists() {
+        let api = TestCloudflareApi::new(vec!["test-zone-id".to_string()]);
+        api.account_tokens.borrow_mut().push((
+            "existing".to_string(),
+            LINKUP_ACCOUNT_TOKEN_NAME.to_string(),
+        ));
+
+        let notifier = TestNotifier {
+            messages: RefCell::new(vec![]),
+            confirmation_response: true,
+            confirmations_asked: RefCell::new(0),
+        };
+
+        let resources = test_resources();
+        let _mocks = mock_cloudflare_endpoints(&resources);
+
+        // Call deploy_to_cloudflare directly
+        let result =
+            deploy_to_cloudflare(&resources, &api, &cloudflare_test_client(), &notifier).await;
+        assert!(result.is_ok());
+
+        let tokens = api.account_tokens.borrow();
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0].0, "existing".to_string());
+        assert_eq!(tokens[0].1, LINKUP_ACCOUNT_TOKEN_NAME.to_string());
+    }
+
+    #[tokio::test]
+    async fn test_deploy_and_destroy_real_integration() {
         // Skip test if environment variables aren't set
         let account_id = match std::env::var("CLOUDFLARE_ACCOUNT_ID") {
             Ok(val) => val,
@@ -894,5 +904,40 @@ export default {
             "Linkup account token '{}' still exists after destroy.",
             linkup_account_token.unwrap().id,
         );
+    }
+
+    // NOTE(augustoccesar)[2025-02-19]: This does not cover for testing when the binding for WORKER_TOKEN is already set.
+    //   This code just allows us to keep the current tests working.
+    fn mock_cloudflare_endpoints(resources: &TargetCfResources) -> Vec<mockito::Mock> {
+        use cloudflare::framework::endpoint::spec::EndpointSpec;
+
+        let req = cloudflare::endpoints::workers::ListBindings {
+            account_id: &resources.account_id,
+            script_name: &resources.worker_script_name,
+        };
+
+        let res = serde_json::to_string(&cloudflare::framework::response::ApiSuccess::<Vec<()>> {
+            result: vec![],
+            result_info: None,
+            messages: serde_json::json!([]),
+            errors: vec![],
+        })
+        .unwrap();
+
+        let path = format!("/{}", req.path().to_string().as_str());
+        let bindings_mock = mockito::mock("GET", path.as_str()).with_body(res).create();
+
+        vec![bindings_mock]
+    }
+
+    fn cloudflare_test_client() -> cloudflare::framework::async_api::Client {
+        cloudflare::framework::async_api::Client::new(
+            cloudflare::framework::auth::Credentials::UserAuthToken {
+                token: "token_123".to_string(),
+            },
+            cloudflare::framework::HttpApiClientConfig::default(),
+            cloudflare::framework::Environment::Mockito,
+        )
+        .expect("Cloudflare test client to have been created")
     }
 }

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -1,6 +1,7 @@
 use axum::{
     extract::{Json, Query, Request, State},
     http::StatusCode,
+    middleware::{from_fn_with_state, Next},
     response::IntoResponse,
     routing::{any, get, post},
     Router,
@@ -14,7 +15,7 @@ use linkup::{
 };
 use serde::{Deserialize, Serialize};
 use tower_service::Service;
-use worker::{event, kv::KvStore, Env, Fetch, HttpRequest, HttpResponse};
+use worker::{console_warn, event, kv::KvStore, Env, Fetch, HttpRequest, HttpResponse};
 use ws::handle_ws_resp;
 
 mod http_error;
@@ -31,6 +32,7 @@ pub struct CloudflareEnvironemnt {
     tunnel_zone_id: String,
     all_zone_ids: Vec<String>,
     api_token: String,
+    worker_token: String,
 }
 
 #[derive(Clone)]
@@ -50,6 +52,7 @@ pub fn linkup_router(state: LinkupState) -> Router {
         .route("/linkup/no-tunnel", get(no_tunnel))
         .merge(routes::certificate_dns::router())
         .merge(routes::certificate_cache::router())
+        .route_layer(from_fn_with_state(state.clone(), authenticate))
         // Fallback for all other requests
         .fallback(any(linkup_request_handler))
         .with_state(state)
@@ -75,6 +78,7 @@ async fn fetch(
         .map(String::from)
         .collect();
     let cf_api_token = env.var("CLOUDFLARE_API_TOKEN")?;
+    let worker_token = env.var("WORKER_TOKEN")?;
 
     let state = LinkupState {
         sessions_kv,
@@ -85,6 +89,7 @@ async fn fetch(
             tunnel_zone_id: cf_tunnel_zone_id.to_string(),
             all_zone_ids: cf_all_zone_ids,
             api_token: cf_api_token.to_string(),
+            worker_token: worker_token.to_string(),
         },
     };
 
@@ -443,4 +448,39 @@ pub fn generate_secret() -> String {
     getrandom::getrandom(&mut random_bytes).unwrap();
 
     base64::Engine::encode(&base64::prelude::BASE64_STANDARD, random_bytes)
+}
+
+async fn authenticate(
+    State(state): State<LinkupState>,
+    headers: HeaderMap,
+    request: Request,
+    next: Next,
+) -> impl IntoResponse {
+    if request.uri().path().starts_with("/linkup/certificate") {
+        let authorization = headers.get(http::header::AUTHORIZATION);
+        match authorization {
+            Some(token) => match token.to_str() {
+                Ok(token) => {
+                    let parsed_token = token.replace("Bearer ", "");
+                    if parsed_token != state.cloudflare.worker_token {
+                        return StatusCode::UNAUTHORIZED.into_response();
+                    }
+                }
+                Err(err) => {
+                    console_warn!(
+                        "Token on Authorization header contains unsupported characters: '{:?}', {}",
+                        token,
+                        err.to_string()
+                    );
+
+                    return StatusCode::UNAUTHORIZED.into_response();
+                }
+            },
+            None => {
+                return StatusCode::UNAUTHORIZED.into_response();
+            }
+        }
+    }
+
+    next.run(request).await
 }

--- a/worker/wrangler.toml.sample
+++ b/worker/wrangler.toml.sample
@@ -13,6 +13,7 @@ CLOUDFLARE_ACCOUNT_ID = ""
 CLOUDFLARE_TUNNEL_ZONE_ID = ""
 CLOUDLFLARE_ALL_ZONE_IDS = ""
 CLOUDFLARE_API_TOKEN = ""
+WORKER_TOKEN = ""
 
 [build]
 command = "cargo install -q worker-build && worker-build --release"


### PR DESCRIPTION
Related changes:
- https://github.com/mentimeter/caddy-storage-linkup/commit/f7326fea11ebbc9ca6c61cfab48e11c9b1ca080d
- https://github.com/mentimeter/caddy-dns-linkup/commit/f80bbfcbeb0d0d7c51d8e7ffab8b789c0ccfc344

Closes DO-1928