### PR TITLE
feat(cli,worker): send header to worker with client version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "linkup-cli"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "base64",
  "clap",

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkup-cli"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 
 [[bin]]

--- a/linkup-cli/src/worker_client.rs
+++ b/linkup-cli/src/worker_client.rs
@@ -48,6 +48,10 @@ impl WorkerClient {
             .expect("token to contain only valid bytes");
         auth_value.set_sensitive(true);
         headers.insert(header::AUTHORIZATION, auth_value);
+        headers.insert(
+            "x-linkup-version",
+            header::HeaderValue::from_static(crate::CURRENT_VERSION),
+        );
 
         let client = reqwest::Client::builder()
             .default_headers(headers)


### PR DESCRIPTION
This will also start do decline requests from clients that are older than the minimum supported version.
The minimum supported version is being set as 2.1.0, which is the one being released by this change.