### PR TITLE
Maintain linkup worker token across deploys

### DIFF
--- a/cloudflare/src/endpoints/workers/mod.rs
+++ b/cloudflare/src/endpoints/workers/mod.rs
@@ -91,6 +91,7 @@ impl ApiResult for Vec<WorkersTail> {}
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct WorkersBinding {
     pub name: String,
+    pub text: Option<String>,
     pub r#type: String,
     // Namespace is not guarantee to exist on all bindings. It exists for type `kv_namespace`, but not for `plain_text`, for example.
     // This should probably be an enum over the possible types of bindings. Something like what we did on deploy/api.rs:


### PR DESCRIPTION
```
The following changes are needed:
DeployPlan {
    kv_actions: [],
    script_action: Some(
        Upload {
            script_name: "linkup-worker-xxx",
            metadata: WorkerMetadata {
                main_module: "shim.mjs",
                bindings: [
                    KvNamespace {
                        name: "LINKUP_SESSIONS",
                        namespace_id: "<to-be-filled-on-deploy>",
                    },
                    KvNamespace {
                        name: "LINKUP_TUNNELS",
                        namespace_id: "<to-be-filled-on-deploy>",
                    },
                    KvNamespace {
                        name: "LINKUP_CERTIFICATE_CACHE",
                        namespace_id: "<to-be-filled-on-deploy>",
                    },
                   
                    PlainText {
                        name: "WORKER_TOKEN",
                        text: "yayitworks",
                    },
                ],
                compatibility_date: "2024-12-18",
                tag: "127b05e1728dc8ee41e1e9f91c2d9936720b4efe048ab5a20758d0c15e7c87ff",
            },
            parts: [
                WorkerScriptPart {
                    name: "shim.mjs",
                    content_type: "application/javascript+module",
                },
                WorkerScriptPart {
                    name: "index.wasm",
                    content_type: "application/wasm",
                },
            ],
        },
    ),
    worker_subdomain_action: None,
    worker_schedules_action: None,
    dns_actions: [],
    route_actions: [],
    ruleset_actions: [],
    account_token_action: None,
}
```

Closes DO-1964