### PR TITLE
fix(ci): Caddy workflow not being triggered

### DIFF
--- a/.github/workflows/caddy.yml
+++ b/.github/workflows/caddy.yml
@@ -8,7 +8,7 @@ on:
         required: true
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*'
 
 jobs:
   build-and-release:


### PR DESCRIPTION
The Caddy build workflow has not being triggered automatically when the tag is created on release. It seems like the format is correct, following the GitHub docs:

- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore

But it is not working as expected. This changes from using `[0-9]+.[0-9]+.[0-9]+` to using `[0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*` in an attempt to fix the triggering.

Closes DO-1965