### PR TITLE
feat(cli): better handle different installation methods

### DIFF
--- a/linkup-cli/src/commands/uninstall.rs
+++ b/linkup-cli/src/commands/uninstall.rs
@@ -1,6 +1,6 @@
 use std::{fs, process};
 
-use crate::{commands, linkup_dir_path, CliError};
+use crate::{commands, linkup_dir_path, linkup_exe_path, CliError, InstallationMethod};
 
 #[derive(clap::Args)]
 pub struct Args {}
@@ -8,35 +8,41 @@ pub struct Args {}
 pub fn uninstall(_args: &Args) -> Result<(), CliError> {
     commands::stop(&commands::StopArgs {}, true)?;
 
+    let exe_path = linkup_exe_path();
+
+    log::debug!("Linkup exe path: {:?}", &exe_path);
+    match InstallationMethod::current() {
+        InstallationMethod::Brew => {
+            log::debug!("Uninstalling linkup from Homebrew");
+
+            process::Command::new("brew")
+                .args(["uninstall", "linkup"])
+                .stdin(process::Stdio::null())
+                .stdout(process::Stdio::null())
+                .stderr(process::Stdio::null())
+                .status()?;
+        }
+        InstallationMethod::Cargo => {
+            log::debug!("Uninstalling linkup from Cargo");
+
+            process::Command::new("cargo")
+                .args(["uninstall", "linkup-cli"])
+                .stdin(process::Stdio::null())
+                .stdout(process::Stdio::null())
+                .stderr(process::Stdio::null())
+                .status()?;
+        }
+        InstallationMethod::Manual => {
+            log::debug!("Uninstalling linkup");
+
+            fs::remove_file(&exe_path)?;
+        }
+    }
+
     let linkup_dir = linkup_dir_path();
 
     log::debug!("Removing linkup folder: {}", linkup_dir.display());
     fs::remove_dir_all(linkup_dir)?;
-
-    let exe_path = fs::canonicalize(std::env::current_exe()?)?
-        .display()
-        .to_string();
-
-    log::debug!("Linkup exe path: {}", &exe_path);
-    if exe_path.contains("homebrew") {
-        log::debug!("Uninstalling linkup from Homebrew");
-
-        process::Command::new("brew")
-            .args(["uninstall", "linkup"])
-            .stdin(process::Stdio::null())
-            .stdout(process::Stdio::null())
-            .stderr(process::Stdio::null())
-            .status()?;
-    } else if exe_path.contains(".cargo") {
-        log::debug!("Uninstalling linkup from Cargo");
-
-        process::Command::new("cargo")
-            .args(["uninstall", "linkup-cli"])
-            .stdin(process::Stdio::null())
-            .stdout(process::Stdio::null())
-            .stderr(process::Stdio::null())
-            .status()?;
-    }
 
     println!("linkup uninstalled!");
 

--- a/linkup-cli/src/commands/update.rs
+++ b/linkup-cli/src/commands/update.rs
@@ -1,4 +1,6 @@
-use crate::{current_version, linkup_exe_path, release, CliError};
+use crate::{
+    current_version, linkup_bin_dir_path, linkup_exe_path, release, CliError, InstallationMethod,
+};
 use std::{fs, path::PathBuf};
 
 #[derive(clap::Args)]
@@ -54,16 +56,14 @@ pub async fn new_version_available() -> bool {
 }
 
 pub fn update_command() -> String {
-    match crate::InstallationMethod::current() {
-        crate::InstallationMethod::Brew => "brew upgrade linkup".to_string(),
-        crate::InstallationMethod::Manual | crate::InstallationMethod::Cargo => {
-            "linkup update".to_string()
-        }
+    match InstallationMethod::current() {
+        InstallationMethod::Brew => "brew upgrade linkup".to_string(),
+        InstallationMethod::Manual | InstallationMethod::Cargo => "linkup update".to_string(),
     }
 }
 
 fn get_caddy_path() -> PathBuf {
-    let mut path = crate::linkup_bin_dir_path();
+    let mut path = linkup_bin_dir_path();
     path.push("caddy");
 
     path

--- a/linkup-cli/src/commands/update.rs
+++ b/linkup-cli/src/commands/update.rs
@@ -1,4 +1,4 @@
-use crate::{current_version, release, CliError};
+use crate::{current_version, linkup_exe_path, release, CliError};
 use std::{fs, path::PathBuf};
 
 #[derive(clap::Args)]
@@ -19,7 +19,7 @@ pub async fn update(args: &Args) -> Result<(), CliError> {
         Some(update) => {
             let new_linkup_path = update.linkup.download_decompressed("linkup").await.unwrap();
 
-            let current_linkup_path = get_exe_path().expect("failed to get the current exe path");
+            let current_linkup_path = linkup_exe_path();
             let bkp_linkup_path = current_linkup_path.with_extension("bkp");
 
             fs::rename(&current_linkup_path, &bkp_linkup_path)
@@ -53,10 +53,13 @@ pub async fn new_version_available() -> bool {
         .is_some()
 }
 
-// Get the current exe path. Using canonicalize ensure that we follow the symlink in case it is one.
-// This is important in case the version is one installed with Homebrew.
-fn get_exe_path() -> Result<PathBuf, std::io::Error> {
-    fs::canonicalize(std::env::current_exe()?)
+pub fn update_command() -> String {
+    match crate::InstallationMethod::current() {
+        crate::InstallationMethod::Brew => "brew upgrade linkup".to_string(),
+        crate::InstallationMethod::Manual | crate::InstallationMethod::Cargo => {
+            "linkup update".to_string()
+        }
+    }
 }
 
 fn get_caddy_path() -> PathBuf {

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -35,7 +35,7 @@ impl InstallationMethod {
             }
         }
 
-        return Self::Manual;
+        Self::Manual
     }
 }
 

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -19,6 +19,31 @@ const LINKUP_LOCALSERVER_PORT: u16 = 9066;
 const LINKUP_DIR: &str = ".linkup";
 const LINKUP_STATE_FILE: &str = "state";
 
+pub enum InstallationMethod {
+    Brew,
+    Cargo,
+    Manual,
+}
+
+impl InstallationMethod {
+    fn current() -> Self {
+        for component in linkup_exe_path().components() {
+            if component.as_os_str() == "Cellar" {
+                return Self::Brew;
+            } else if component.as_os_str() == ".cargo" {
+                return Self::Cargo;
+            }
+        }
+
+        return Self::Manual;
+    }
+}
+
+pub fn linkup_exe_path() -> PathBuf {
+    fs::canonicalize(std::env::current_exe().expect("current exe to be accessible"))
+        .expect("exe path to be valid")
+}
+
 pub fn linkup_dir_path() -> PathBuf {
     let storage_dir = match env::var("HOME") {
         Ok(val) => val,
@@ -246,10 +271,13 @@ async fn main() -> Result<()> {
     if !matches!(cli.command, Commands::Update(_))
         && commands::update::new_version_available().await
     {
-        println!(
-            "{}",
-            "⚠️ New version of linkup is available! Run `linkup update` to update it.".yellow()
-        );
+        let message = format!(
+            "⚠️ New version of linkup is available! Run `{}` to update it.",
+            commands::update::update_command()
+        )
+        .yellow();
+
+        println!("{}", message);
     }
 
     match &cli.command {


### PR DESCRIPTION
This points homebrew installations to use `brew upgrade` instead of `linkup update`.