### PR TITLE
feat(cli): build worker automatically when building cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,6 @@ jobs:
           rustup target add ${{ matrix.target }}
           rustup show
 
-      - name: Build Worker
-        working-directory: worker
-        run: cargo install -q worker-build && worker-build --release
-
       - name: Build
         run: cargo build --release --manifest-path linkup-cli/Cargo.toml  --target ${{ matrix.target }}
 

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "linkup-cli"
 version = "2.2.0"
 edition = "2021"
+build = "build.rs"
 
 [[bin]]
 name = "linkup"

--- a/linkup-cli/build.rs
+++ b/linkup-cli/build.rs
@@ -9,7 +9,7 @@ fn main() {
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR to be set");
 
     let install_status = Command::new("cargo")
-        .args(&["install", "-q", "worker-build"])
+        .args(["install", "-q", "worker-build"])
         .current_dir("../worker")
         .status()
         .expect("failed to execute worker-build install process");
@@ -19,7 +19,7 @@ fn main() {
     }
 
     let build_status = Command::new("worker-build")
-        .args(&["--release"])
+        .args(["--release"])
         .current_dir("../worker")
         .status()
         .expect("failed to execute worker-build process");
@@ -35,6 +35,6 @@ fn main() {
 
     fs::create_dir_all(&out_dir).expect("failed to create output directories");
 
-    fs::copy(&shim_src, &shim_dest).expect("failed to copy shim.mjs");
-    fs::copy(&wasm_src, &wasm_dest).expect("failed to copy index.wasm");
+    fs::copy(shim_src, &shim_dest).expect("failed to copy shim.mjs");
+    fs::copy(wasm_src, &wasm_dest).expect("failed to copy index.wasm");
 }

--- a/linkup-cli/build.rs
+++ b/linkup-cli/build.rs
@@ -1,0 +1,40 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+    println!("cargo::rerun-if-changed=../worker/src");
+
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR to be set");
+
+    let install_status = Command::new("cargo")
+        .args(&["install", "-q", "worker-build"])
+        .current_dir("../worker")
+        .status()
+        .expect("failed to execute worker-build install process");
+
+    if !install_status.success() {
+        panic!("Failed to install worker-build");
+    }
+
+    let build_status = Command::new("worker-build")
+        .args(&["--release"])
+        .current_dir("../worker")
+        .status()
+        .expect("failed to execute worker-build process");
+
+    if !build_status.success() {
+        panic!("Failed to build worker");
+    }
+
+    let shim_src = Path::new("../worker/build/worker/shim.mjs");
+    let wasm_src = Path::new("../worker/build/worker/index.wasm");
+    let shim_dest = Path::new(&out_dir).join("shim.mjs");
+    let wasm_dest = Path::new(&out_dir).join("index.wasm");
+
+    fs::create_dir_all(&out_dir).expect("failed to create output directories");
+
+    fs::copy(&shim_src, &shim_dest).expect("failed to copy shim.mjs");
+    fs::copy(&wasm_src, &wasm_dest).expect("failed to copy index.wasm");
+}

--- a/linkup-cli/src/commands/deploy/resources.rs
+++ b/linkup-cli/src/commands/deploy/resources.rs
@@ -7,11 +7,8 @@ use sha2::{Digest, Sha256};
 
 use super::{api::CloudflareApi, cf_deploy::DeployNotifier, DeployError};
 
-// To build the worker script, run in the worker directory:
-// cargo install -q worker-build && worker-build --release
-const LINKUP_WORKER_SHIM: &[u8] = include_bytes!("../../../../worker/build/worker/shim.mjs");
-const LINKUP_WORKER_INDEX_WASM: &[u8] =
-    include_bytes!("../../../../worker/build/worker/index.wasm");
+const LINKUP_WORKER_SHIM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/shim.mjs"));
+const LINKUP_WORKER_INDEX_WASM: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/index.wasm"));
 
 #[derive(Debug, Clone)]
 pub struct TargetCfResources {


### PR DESCRIPTION
Currently to run the build of the CLI, it is necessary to run the worker build before:
```
cargo install -q worker-build && worker-build --release
```

Now the worker will be built automatically when building the CLI if there has been any changes to worker source code.

### References
- Build scripts - https://doc.rust-lang.org/cargo/reference/build-scripts.html