### PR TITLE
fix(ci): only run release if version changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,42 @@ on:
       - "linkup-cli/Cargo.toml"
 
 jobs:
+  check_version:
+    name: Check if Version Changed
+    runs-on: ubuntu-latest
+    outputs:
+      version_changed: ${{ steps.check.outputs.version_changed }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check Version
+        id: check
+        run: |
+          new_version=$(grep '^version = ' linkup-cli/Cargo.toml | sed -E 's/version = "(.*)"/\1/')
+          old_version=$(git show HEAD^:linkup-cli/Cargo.toml | grep '^version = ' | sed -E 's/version = "(.*)"/\1/')
+
+          echo "New version: $new_version"
+          echo "Old version: $old_version"
+
+          if [ "$new_version" = "$old_version" ]; then
+            echo "No version change detected."
+            echo "version_changed=false" >> $GITHUB_OUTPUT
+            echo "new_version=''" >> $GITHUB_OUTPUT
+          else
+            echo "Version change detected."
+            echo "version_changed=true" >> $GITHUB_OUTPUT
+            echo "new_version=$new_version" >> $GITHUB_OUTPUT
+          fi
+
   build:
+    needs: [check_version]
     name: Build
     runs-on: ${{matrix.os}}
+    if: ${{ needs.check_version.outputs.version_changed == 'true' }}
     strategy:
       matrix:
         include:
@@ -148,8 +181,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   update_homebrew_formula:
-    needs: [build]
+    needs: [build, check_version]
     runs-on: ubuntu-latest
+    if: ${{ needs.check_version.outputs.version_changed == 'true' }}
     steps:
       - name: Checkout Homebrew Tap Repository
         run: git clone https://github.com/mentimeter/homebrew-mentimeter.git


### PR DESCRIPTION
Currently, if there is any change to the toml file it will trigger the release workflow. So, if we bump dependencies, for example, it would trigger the workflow, which is not what we want.