### PR TITLE
fix: allow HTTPS server to run without certificates

### DIFF
--- a/local-server/src/certificates/wildcard_sni_resolver.rs
+++ b/local-server/src/certificates/wildcard_sni_resolver.rs
@@ -33,7 +33,13 @@ impl WildcardSniResolver {
     pub fn load_dir(certs_dir: &Path) -> Result<Self, WildcardSniResolverError> {
         let resolver = WildcardSniResolver::new();
 
-        let entries = fs::read_dir(certs_dir)?;
+        let entries = match fs::read_dir(certs_dir) {
+            Ok(entries) => entries,
+            Err(error) => match error.kind() {
+                std::io::ErrorKind::NotFound => return Ok(resolver),
+                _ => return Err(error.into()),
+            },
+        };
 
         for entry in entries.flatten() {
             let path = entry.path();


### PR DESCRIPTION
Currently, if the certificates folder does not exist, the HTTPS server fails to start. With the current setup, if any of the two servers (HTTP or HTTPS) exits, it stops the other one.

This is causing issue where, if the user does not have local-dns installed, they won't have the certificates folder, and by consequence the HTTPS server will not start and kill the HTTP server.

These changes allow the HTTPS server to start without any certificate.

Related to SHIP-2057