### PR TITLE
feat(cli, next): remove sudo requirement on start/stop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,6 +1649,7 @@ dependencies = [
  "tokio",
  "tower 0.5.2",
  "tower-http",
+ "tracing",
 ]
 
 [[package]]

--- a/linkup-cli/src/commands/local_dns.rs
+++ b/linkup-cli/src/commands/local_dns.rs
@@ -39,7 +39,7 @@ pub async fn install(config_arg: &Option<String>) -> Result<()> {
         println!("  - Ensure there is a folder /etc/resolvers");
         println!("  - Create file(s) for /etc/resolver/<domain>");
         println!("  - Add Linkup CA certificate to keychain");
-        println!("  - Register port forwarding to 80 and 443");
+        println!("  - Register port forwarding for 80 and 443");
         println!("  - Flush DNS cache");
 
         sudo_su()?;

--- a/linkup-cli/src/commands/start.rs
+++ b/linkup-cli/src/commands/start.rs
@@ -14,10 +14,8 @@ use crossterm::{cursor, ExecutableCommand};
 use crate::{
     commands::status::{format_state_domains, SessionStatus},
     env_files::write_to_env_file,
-    is_sudo,
     local_config::{config_path, config_to_state, get_config},
     services::{self, BackgroundService},
-    sudo_su,
 };
 use crate::{local_config::LocalState, CliError};
 
@@ -77,14 +75,6 @@ pub async fn start(
     // we store any error that might happen on one of the steps and only return it after we have
     // send the message to the display thread to stop and we join it.
     let mut exit_error: Option<Box<dyn std::error::Error>> = None;
-
-    // TODO(augustoccesar)[2025-03-11]: Since we are binding now on 80 and 443 ourselves, we need
-    //   to get sudo permission. Ideally this wouldn't be necessary, so we should take a look if/how
-    //   we can avoid needing it. Caddy was able to bind on them without sudo (at least on macos),
-    //   so there could be a way.
-    if !is_sudo() {
-        sudo_su()?;
-    }
 
     match local_server
         .run_with_progress(&mut state, status_update_channel.0.clone())

--- a/linkup-cli/src/commands/stop.rs
+++ b/linkup-cli/src/commands/stop.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::env_files::clear_env_file;
 use crate::local_config::LocalState;
-use crate::{is_sudo, services, sudo_su, CliError};
+use crate::{services, CliError};
 
 #[derive(clap::Args)]
 pub struct Args {}
@@ -27,14 +27,6 @@ pub fn stop(_args: &Args, clear_env: bool) -> Result<(), CliError> {
         (Err(err), _) => {
             log::warn!("Failed to fetch local state: {}", err);
         }
-    }
-
-    // TODO(augustoccesar)[2025-03-11]: Since we are binding now on 80 and 443 ourselves, we need
-    //   to get sudo permission. Ideally this wouldn't be necessary, so we should take a look if/how
-    //   we can avoid needing it. Caddy was able to bind on them without sudo (at least on macos),
-    //   so there could be a way.
-    if !is_sudo() {
-        sudo_su()?;
     }
 
     services::LocalServer::new().stop();

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -2,7 +2,8 @@ use std::{env, fs, io::ErrorKind, path::PathBuf, process};
 
 use clap::{Parser, Subcommand};
 use colored::Colorize;
-use linkup_local_server::port_forwarding::{is_port_forwarding_active, setup_port_forwarding};
+use commands::local_dns;
+use linkup_local_server::{is_port_forwarding_active, setup_port_forwarding};
 use thiserror::Error;
 
 pub use linkup::Version;
@@ -275,7 +276,12 @@ async fn main() -> Result<()> {
 
     ensure_linkup_dir()?;
 
-    if !is_port_forwarding_active() {
+    // TODO(augustoccesar)[2025-03-20]: We should look if is better to not have the state loaded
+    //   from so many places. Maybe we can have in here a load a mutable state and pass it down to
+    //   where it is necessary. Not sure if would be better, but maybe worth looking.
+    if local_dns::is_installed(local_config::LocalState::load().ok().as_ref())
+        && !is_port_forwarding_active()
+    {
         if !is_sudo() {
             println!("Looks like you are running linkup for the first time on this session.");
             println!("We need to register ports forwarding for the local server and for that we need sudo access.");

--- a/linkup-cli/src/services/cloudflare_tunnel.rs
+++ b/linkup-cli/src/services/cloudflare_tunnel.rs
@@ -348,7 +348,7 @@ fn create_config_yml(tunnel_id: &str) -> Result<(), Error> {
     let credentials_file_path_str = credentials_file_path.to_string_lossy().to_string();
 
     let config = Config {
-        url: "http://localhost".to_string(),
+        url: format!("http://localhost:{}", linkup_local_server::HTTP_PORT),
         tunnel: tunnel_id.to_string(),
         credentials_file: credentials_file_path_str,
     };

--- a/linkup-cli/src/services/local_server.rs
+++ b/linkup-cli/src/services/local_server.rs
@@ -46,9 +46,8 @@ impl LocalServer {
         }
     }
 
-    /// For internal communication to local-server, we only use the port 80 (HTTP).
     pub fn url() -> Url {
-        Url::parse("http://localhost:80").expect("linkup url invalid")
+        Url::parse("http://localhost").expect("linkup url invalid")
     }
 
     fn start(&self) -> Result<(), Error> {
@@ -59,9 +58,8 @@ impl LocalServer {
 
         // When running with cargo (e.g. `cargo run -- start`), we should start the server also with cargo.
         let mut command = if env::var("CARGO").is_ok() {
-            let mut cmd = process::Command::new("sudo");
+            let mut cmd = process::Command::new("cargo");
             cmd.args([
-                "cargo",
                 "run",
                 "--",
                 "server",

--- a/linkup-cli/src/services/local_server.rs
+++ b/linkup-cli/src/services/local_server.rs
@@ -59,6 +59,7 @@ impl LocalServer {
         // When running with cargo (e.g. `cargo run -- start`), we should start the server also with cargo.
         let mut command = if env::var("CARGO").is_ok() {
             let mut cmd = process::Command::new("cargo");
+            cmd.env("RUST_LOG", "debug");
             cmd.args([
                 "run",
                 "--",

--- a/linkup-cli/src/services/local_server.rs
+++ b/linkup-cli/src/services/local_server.rs
@@ -47,7 +47,11 @@ impl LocalServer {
     }
 
     pub fn url() -> Url {
-        Url::parse("http://localhost").expect("linkup url invalid")
+        Url::parse(&format!(
+            "http://localhost:{}",
+            linkup_local_server::HTTP_PORT
+        ))
+        .expect("linkup url invalid")
     }
 
     fn start(&self) -> Result<(), Error> {

--- a/local-server/Cargo.toml
+++ b/local-server/Cargo.toml
@@ -16,6 +16,7 @@ hyper-rustls = { version = "0.27.5", default-features = false, features = ["http
 hyper-util = { version = "0.1.10", features = ["client-legacy"] }
 futures = "0.3.31"
 linkup = { path = "../linkup" }
+tracing = {version = "0.1"}
 rustls = { version = "0.23.21", default-features = false, features = ["ring"] }
 rustls-native-certs = "0.8.1"
 thiserror = "2.0.11"

--- a/local-server/src/lib.rs
+++ b/local-server/src/lib.rs
@@ -97,7 +97,7 @@ pub async fn start_server_https(config_store: MemoryStringStore, certs_dir: &Pat
 
     let app = linkup_router(config_store);
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], HTTPS_PORT));
+    let addr = SocketAddr::from(([127, 0, 0, 1], HTTPS_PORT));
     println!("listening on {}", &addr);
 
     axum_server::bind_rustls(addr, RustlsConfig::from_config(Arc::new(server_config)))
@@ -109,7 +109,7 @@ pub async fn start_server_https(config_store: MemoryStringStore, certs_dir: &Pat
 pub async fn start_server_http(config_store: MemoryStringStore) -> std::io::Result<()> {
     let app = linkup_router(config_store);
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], HTTP_PORT));
+    let addr = SocketAddr::from(([127, 0, 0, 1], HTTP_PORT));
     println!("listening on {}", &addr);
 
     let listener = TcpListener::bind(addr)?;

--- a/local-server/src/lib.rs
+++ b/local-server/src/lib.rs
@@ -1,3 +1,6 @@
+pub mod certificates;
+mod port_forwarding;
+
 use axum::{
     body::Body,
     extract::{DefaultBodyLimit, Json, Request},
@@ -23,8 +26,9 @@ use std::{path::Path, sync::Arc};
 use tower::ServiceBuilder;
 use tower_http::trace::{DefaultOnRequest, DefaultOnResponse, TraceLayer};
 
-pub mod certificates;
-pub mod port_forwarding;
+pub use port_forwarding::{
+    is_port_forwarding_active, reset_port_forwarding, setup_port_forwarding,
+};
 
 pub const HTTP_PORT: u16 = 8080;
 pub const HTTPS_PORT: u16 = 8443;

--- a/local-server/src/lib.rs
+++ b/local-server/src/lib.rs
@@ -142,7 +142,7 @@ async fn linkup_request_handler(
             req.headers()
                 .get(http::header::HOST)
                 .and_then(|h| h.to_str().ok())
-                .unwrap_or("localhost"),
+                .unwrap_or(&format!("localhost:{}", HTTP_PORT)),
             req.uri()
         )
     };

--- a/local-server/src/port_forwarding.rs
+++ b/local-server/src/port_forwarding.rs
@@ -66,13 +66,13 @@ rdr pass on lo0 inet proto tcp from any to any port 443 -> 127.0.0.1 port 8443
         }
     }
 
-    let status = process::Command::new("sudo")
+    let load_config_status = process::Command::new("sudo")
         .args(["pfctl", "-f", PORTS_CONFIG])
         .stdin(process::Stdio::null())
         .stdout(process::Stdio::null())
         .stderr(process::Stdio::null())
         .status()?;
-    if !status.success() {
+    if !load_config_status.success() {
         tracing::event!(
             tracing::Level::ERROR,
             "Failed to load {PORTS_CONFIG} into pfctl."

--- a/local-server/src/port_forwarding.rs
+++ b/local-server/src/port_forwarding.rs
@@ -25,6 +25,7 @@ pub fn setup_port_forwarding() -> Result<(), Box<dyn std::error::Error>> {
 
     let content = r#"rdr pass on lo0 inet proto tcp from any to any port 80 -> 127.0.0.1 port 8080
 rdr pass on lo0 inet proto tcp from any to any port 443 -> 127.0.0.1 port 8443
+pass in quick on lo0 proto tcp from any to any port 8080
 "#;
 
     let temp_ports_config_path = "/tmp/pf.linkup.ports.conf.tmp";

--- a/local-server/src/port_forwarding.rs
+++ b/local-server/src/port_forwarding.rs
@@ -1,0 +1,90 @@
+// To avoid needing to sudo every time we start or stop the local server, we add the port
+// forwardings 8080->80 and 8443->443 so that we can start the local server on 8080 and 8443
+// while still being able to resolve the dnsmasq to 80 and 443.
+// This will make so that the user will need to sudo once only and then after the port forwardings
+// are in place it won't be necessary anymore.
+//
+// Note that, since we are using `pfctl -f <PORTS CONF>`, it will be reset if the user restart their
+// computer. For that reason, we are also storing the flag file on a tmp folder, so that the check
+// also reset on a computer restart.
+//
+// This means that if the user restart the computer, the first run of linkup will require sudo
+// again.
+
+use std::{io::Write, path::Path, process};
+
+const PORTS_CONFIG: &str = "/etc/pf.linkup.ports.conf";
+const FLAG_FILE: &str = "/tmp/port_forwarding_active";
+
+pub fn is_port_forwarding_active() -> bool {
+    Path::new(FLAG_FILE).exists()
+}
+
+pub fn setup_port_forwarding() -> Result<(), Box<dyn std::error::Error>> {
+    tracing::event!(tracing::Level::DEBUG, "Setting up port forwarding.");
+
+    let content = r#"rdr pass on lo0 inet proto tcp from any to any port 80 -> 127.0.0.1 port 8080
+rdr pass on lo0 inet proto tcp from any to any port 443 -> 127.0.0.1 port 8443
+"#;
+
+    let mut tee_cmd = process::Command::new("sudo")
+        .args(["tee", PORTS_CONFIG])
+        .stdin(process::Stdio::piped()) // We will write to here to persist the file
+        .stdout(process::Stdio::null())
+        .stderr(process::Stdio::null())
+        .spawn()?;
+
+    if let Some(mut stdin) = tee_cmd.stdin.take() {
+        stdin.write_all(content.as_bytes())?;
+    }
+
+    let status = tee_cmd.wait()?;
+    if !status.success() {
+        tracing::event!(tracing::Level::ERROR, "Failed to write {PORTS_CONFIG}");
+
+        return Err("Failed to write port forwarding config".into());
+    } else {
+        tracing::event!(
+            tracing::Level::DEBUG,
+            "Written port forwardings into {PORTS_CONFIG}",
+        );
+    }
+
+    let enable_output = process::Command::new("sudo")
+        .args(["pfctl", "-e"])
+        .stdin(process::Stdio::null())
+        .stdout(process::Stdio::null())
+        .stderr(process::Stdio::piped()) // We will read from here to check if is already running
+        .output()?;
+    if !enable_output.status.success() {
+        let enable_stderr = String::from_utf8(enable_output.stderr).unwrap();
+        if !enable_stderr.contains("pf already enabled") {
+            tracing::event!(tracing::Level::ERROR, "Failed to enable port forwarding");
+
+            return Err("Failed to enable port forwarding".into());
+        } else {
+            tracing::event!(tracing::Level::DEBUG, "Port forwarding already enabled.");
+        }
+    }
+
+    let status = process::Command::new("sudo")
+        .args(["pfctl", "-f", PORTS_CONFIG])
+        .stdin(process::Stdio::null())
+        .stdout(process::Stdio::null())
+        .stderr(process::Stdio::null())
+        .status()?;
+    if !status.success() {
+        tracing::event!(
+            tracing::Level::ERROR,
+            "Failed to load {PORTS_CONFIG} into pfctl."
+        );
+
+        return Err("Failed to load port forwarding rules".into());
+    } else {
+        tracing::event!(tracing::Level::DEBUG, "Loaded {PORTS_CONFIG} into pfctl.");
+    }
+
+    std::fs::write(Path::new(FLAG_FILE), "")?;
+
+    Ok(())
+}


### PR DESCRIPTION
In this current version of the `next` branch, to start and stop linkup it is required to have sudo.
This is the case because since we don't have Caddy, dnsmasq is now resolving directly to linkup local server. Which means that we have to have it accessible on ports 80 and 443.
Since these ports are protected, we can only do so with sudo.

This PR changes so that we only need sudo once per session (it will be required again on computer restart).
By accomplish this by using port forwarding. With this, we will forward ports `8080 -> 80` and `8443 -> 443`.
Since setting this port forwarding is also a protected action, it needs sudo. But now it should need only once per session.

We are using `pfctl -f <PORTS CONF>`, which is reset if the user restart their computer. For that reason, we are also storing the flag file on a tmp folder, so that the check if port forwarding is enabled also reset on a computer restart. This is on purpose and should help us restoring anything that might go wrong with a computer restart.

### Ruleset
```
rdr pass on lo0 inet proto tcp from any to any port 80 -> 127.0.0.1 port 8080
rdr pass on lo0 inet proto tcp from any to any port 443 -> 127.0.0.1 port 8443
pass in quick on lo0 proto tcp from any to any port 8080
```

#### `rdr pass on lo0 inet proto tcp from any to any port 80 -> 127.0.0.1 port 8080`
- `rdr` -> Redirects incoming packets.
- `pass` -> Allows the redirected packets to continue without further filtering.
- `on lo0` -> This rule applies only to traffic on the loopback interface (lo0).
- `inet` -> This applies to IPv4 traffic.
- `proto tcp` -> Only applies to TCP connections.
- `from any to any port 80` -> Matches any source connecting to port 80.
- `-> 127.0.0.1 port 8080` -> Redirects this traffic to localhost (127.0.0.1) on port 8080.

#### `rdr pass on lo0 inet proto tcp from any to any port 443 -> 127.0.0.1 port 8443`
Same as above but:
- Matches incoming connections to port 443 (HTTPS).
- Redirects them to localhost (127.0.0.1) on port 8443.

#### `pass in quick on lo0 proto tcp from any to any port 8080`
- `pass` -> Allows matching traffic to pass through the firewall.
- `in` -> Applies only to incoming traffic.
- `quick` -> Stops further processing of firewall rules once this matches.
- `on lo0` -> Applies only on the loopback interface (lo0).
- `proto tcp` -> Only affects TCP connections.
- `from any to any port 8080` -> Allows any source to connect to port 8080.

### Resources
- https://man.openbsd.org/pfctl
- https://man.openbsd.org/pf.conf