### PR TITLE
refactor: change from global error enum to anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,6 +1599,7 @@ dependencies = [
 name = "linkup-cli"
 version = "2.2.0"
 dependencies = [
+ "anyhow",
  "base64",
  "clap",
  "clap_complete",

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -9,6 +9,7 @@ name = "linkup"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1"
 clap = { version = "4.5.27", features = ["derive", "cargo"] }
 clap_complete = "4.5.42"
 cloudflare = { path = "../cloudflare", default-features = false, features = [

--- a/linkup-cli/src/commands/completion.rs
+++ b/linkup-cli/src/commands/completion.rs
@@ -3,7 +3,7 @@ use std::io::stdout;
 use clap::{Command, CommandFactory};
 use clap_complete::{generate, Generator, Shell};
 
-use crate::{Cli, CliError};
+use crate::{Cli, Result};
 
 #[derive(clap::Args)]
 pub struct Args {
@@ -11,7 +11,7 @@ pub struct Args {
     shell: Option<Shell>,
 }
 
-pub fn completion(args: &Args) -> Result<(), CliError> {
+pub fn completion(args: &Args) -> Result<()> {
     if let Some(shell) = &args.shell {
         let mut cmd = Cli::command();
         print_completions(shell, &mut cmd);

--- a/linkup-cli/src/commands/deploy/cf_deploy.rs
+++ b/linkup-cli/src/commands/deploy/cf_deploy.rs
@@ -1,5 +1,6 @@
 use crate::commands::deploy::auth;
 use crate::commands::deploy::resources::cf_resources;
+use crate::Result;
 
 use super::api::{AccountCloudflareApi, CloudflareApi};
 use super::console_notify::ConsoleNotifier;
@@ -7,8 +8,6 @@ use super::resources::TargetCfResources;
 
 #[derive(thiserror::Error, Debug)]
 pub enum DeployError {
-    #[error("No authentication method found, please set CLOUDFLARE_API_KEY and CLOUDFLARE_EMAIL or CLOUDFLARE_API_TOKEN")]
-    NoAuthenticationError,
     #[error("Cloudflare API error: {0}")]
     CloudflareApiError(#[from] reqwest::Error),
     #[error("Cloudflare Client error: {0}")]
@@ -45,7 +44,7 @@ pub struct DeployArgs {
     zone_ids: Vec<String>,
 }
 
-pub async fn deploy(args: &DeployArgs) -> Result<(), DeployError> {
+pub async fn deploy(args: &DeployArgs) -> Result<()> {
     println!("Deploying to Cloudflare...");
     println!("Account ID: {}", args.account_id);
     println!("Zone IDs: {:?}", args.zone_ids);
@@ -93,7 +92,7 @@ pub async fn deploy_to_cloudflare(
     api: &impl CloudflareApi,
     cloudflare_client: &cloudflare::framework::async_api::Client,
     notifier: &impl DeployNotifier,
-) -> Result<(), DeployError> {
+) -> Result<()> {
     // 1) Check what needs to change
     let plan = resources.check_deploy_plan(api, cloudflare_client).await?;
 

--- a/linkup-cli/src/commands/deploy/cf_destroy.rs
+++ b/linkup-cli/src/commands/deploy/cf_destroy.rs
@@ -1,10 +1,9 @@
 use crate::commands::deploy::{
     api::AccountCloudflareApi, auth, console_notify::ConsoleNotifier, resources::cf_resources,
 };
+use crate::Result;
 
-use super::{
-    api::CloudflareApi, cf_deploy::DeployNotifier, resources::TargetCfResources, DeployError,
-};
+use super::{api::CloudflareApi, cf_deploy::DeployNotifier, resources::TargetCfResources};
 
 #[derive(clap::Args)]
 pub struct DestroyArgs {
@@ -27,7 +26,7 @@ pub struct DestroyArgs {
     zone_ids: Vec<String>,
 }
 
-pub async fn destroy(args: &DestroyArgs) -> Result<(), DeployError> {
+pub async fn destroy(args: &DestroyArgs) -> Result<()> {
     println!("Destroying from Cloudflare...");
     println!("Account ID: {}", args.account_id);
     println!("Zone IDs: {:?}", args.zone_ids);
@@ -76,7 +75,7 @@ pub async fn destroy_from_cloudflare(
     api: &impl CloudflareApi,
     cloudflare_client: &cloudflare::framework::async_api::Client,
     notifier: &impl DeployNotifier,
-) -> Result<(), DeployError> {
+) -> Result<()> {
     // 1) Check which resources actually exist and need removal
     let plan = resources.check_destroy_plan(api).await?;
 

--- a/linkup-cli/src/commands/local.rs
+++ b/linkup-cli/src/commands/local.rs
@@ -1,6 +1,8 @@
+use anyhow::anyhow;
+
 use crate::{
     local_config::{upload_state, LocalState, ServiceTarget},
-    CliError,
+    Result,
 };
 
 #[derive(clap::Args)]
@@ -16,11 +18,9 @@ pub struct Args {
     all: bool,
 }
 
-pub async fn local(args: &Args) -> Result<(), CliError> {
+pub async fn local(args: &Args) -> Result<()> {
     if args.service_names.is_empty() && !args.all {
-        return Err(CliError::NoSuchService(
-            "No service names provided".to_string(),
-        ));
+        return Err(anyhow!("No service names provided"));
     }
 
     let mut state = LocalState::load()?;
@@ -35,7 +35,8 @@ pub async fn local(args: &Args) -> Result<(), CliError> {
                 .services
                 .iter_mut()
                 .find(|s| s.name.as_str() == service_name)
-                .ok_or_else(|| CliError::NoSuchService(service_name.to_string()))?;
+                .ok_or_else(|| anyhow!("Service with name '{}' does not exist", service_name))?;
+
             service.current = ServiceTarget::Local;
         }
     }

--- a/linkup-cli/src/commands/preview.rs
+++ b/linkup-cli/src/commands/preview.rs
@@ -1,7 +1,8 @@
 use crate::commands::status::{format_state_domains, SessionStatus};
 use crate::local_config::{config_path, get_config};
 use crate::worker_client::WorkerClient;
-use crate::CliError;
+use crate::Result;
+use anyhow::Context;
 use clap::builder::ValueParser;
 use linkup::CreatePreviewRequest;
 
@@ -19,29 +20,32 @@ pub struct Args {
     print_request: bool,
 }
 
-pub async fn preview(args: &Args, config: &Option<String>) -> Result<(), CliError> {
+pub async fn preview(args: &Args, config: &Option<String>) -> Result<()> {
     let config_path = config_path(config)?;
     let input_config = get_config(&config_path)?;
     let create_preview_request: CreatePreviewRequest =
         input_config.create_preview_request(&args.services);
     let url = input_config.linkup.worker_url.clone();
-    let create_req_json = serde_json::to_string(&create_preview_request)
-        .map_err(|e| CliError::LoadConfig(url.to_string(), e.to_string()))?;
 
     if args.print_request {
+        let create_req_json = serde_json::to_string(&create_preview_request)
+            .context("Failed to encode request to JSON string")?;
+
         println!("{}", create_req_json);
+
         return Ok(());
     }
 
     let preview_name = WorkerClient::from(&input_config)
         .preview(&create_preview_request)
         .await
-        .map_err(|e| CliError::LoadConfig(url.to_string(), e.to_string()))?;
+        .with_context(|| format!("Failed to send preview request to {}", url))?;
 
     let status = SessionStatus {
         name: preview_name.clone(),
         domains: format_state_domains(&preview_name, &input_config.domains),
     };
+
     status.print();
 
     Ok(())

--- a/linkup-cli/src/commands/remote.rs
+++ b/linkup-cli/src/commands/remote.rs
@@ -1,7 +1,9 @@
 use crate::{
     local_config::{upload_state, LocalState, ServiceTarget},
-    CliError,
+    Result,
 };
+
+use anyhow::anyhow;
 
 #[derive(clap::Args)]
 pub struct Args {
@@ -16,11 +18,9 @@ pub struct Args {
     all: bool,
 }
 
-pub async fn remote(args: &Args) -> Result<(), CliError> {
+pub async fn remote(args: &Args) -> Result<()> {
     if args.service_names.is_empty() && !args.all {
-        return Err(CliError::NoSuchService(
-            "No service names provided".to_string(),
-        ));
+        return Err(anyhow!("No service names provided"));
     }
 
     let mut state = LocalState::load()?;
@@ -35,7 +35,8 @@ pub async fn remote(args: &Args) -> Result<(), CliError> {
                 .services
                 .iter_mut()
                 .find(|s| s.name.as_str() == service_name)
-                .ok_or_else(|| CliError::NoSuchService(service_name.to_string()))?;
+                .ok_or_else(|| anyhow!("Service with name '{}' does not exist", service_name))?;
+
             service.current = ServiceTarget::Remote;
         }
     }

--- a/linkup-cli/src/commands/reset.rs
+++ b/linkup-cli/src/commands/reset.rs
@@ -1,9 +1,9 @@
-use crate::{commands, local_config::LocalState, CliError};
+use crate::{commands, local_config::LocalState, Result};
 
 #[derive(clap::Args)]
 pub struct Args {}
 
-pub async fn reset(_args: &Args) -> Result<(), CliError> {
+pub async fn reset(_args: &Args) -> Result<()> {
     let _ = LocalState::load()?;
 
     commands::stop(&commands::StopArgs {}, false)?;

--- a/linkup-cli/src/commands/server.rs
+++ b/linkup-cli/src/commands/server.rs
@@ -1,4 +1,4 @@
-use crate::CliError;
+use crate::Result;
 use linkup::MemoryStringStore;
 use std::fs;
 use std::path::Path;
@@ -11,7 +11,7 @@ pub struct Args {
 }
 
 #[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
-pub async fn server(args: &Args, certs_dir: &Path) -> Result<(), CliError> {
+pub async fn server(args: &Args, certs_dir: &Path) -> Result<()> {
     let pid = std::process::id();
     fs::write(&args.pidfile, pid.to_string())?;
 

--- a/linkup-cli/src/commands/start.rs
+++ b/linkup-cli/src/commands/start.rs
@@ -8,6 +8,7 @@ use std::{
     time::Duration,
 };
 
+use anyhow::{anyhow, Context, Error};
 use colored::Colorize;
 use crossterm::{cursor, ExecutableCommand};
 
@@ -17,7 +18,7 @@ use crate::{
     local_config::{config_path, config_to_state, get_config},
     services::{self, BackgroundService},
 };
-use crate::{local_config::LocalState, CliError};
+use crate::{local_config::LocalState, Result};
 
 const LOADING_CHARS: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
@@ -31,11 +32,7 @@ pub struct Args {
     pub no_tunnel: bool,
 }
 
-pub async fn start(
-    args: &Args,
-    fresh_state: bool,
-    config_arg: &Option<String>,
-) -> Result<(), CliError> {
+pub async fn start(args: &Args, fresh_state: bool, config_arg: &Option<String>) -> Result<()> {
     let mut state = if fresh_state {
         let state = load_and_save_state(config_arg, args.no_tunnel, true)?;
         set_linkup_env(state.clone())?;
@@ -74,14 +71,14 @@ pub async fn start(
     // To make sure that we get the last update to the display thread before the error is bubbled up,
     // we store any error that might happen on one of the steps and only return it after we have
     // send the message to the display thread to stop and we join it.
-    let mut exit_error: Option<Box<dyn std::error::Error>> = None;
+    let mut exit_error: Option<Error> = None;
 
     match local_server
         .run_with_progress(&mut state, status_update_channel.0.clone())
         .await
     {
         Ok(_) => (),
-        Err(err) => exit_error = Some(Box::new(err)),
+        Err(err) => exit_error = Some(err),
     }
 
     if exit_error.is_none() {
@@ -90,7 +87,7 @@ pub async fn start(
             .await
         {
             Ok(_) => (),
-            Err(err) => exit_error = Some(Box::new(err)),
+            Err(err) => exit_error = Some(err),
         }
     }
 
@@ -101,7 +98,7 @@ pub async fn start(
             .await
         {
             Ok(_) => (),
-            Err(err) => exit_error = Some(Box::new(err)),
+            Err(err) => exit_error = Some(err),
         }
     }
 
@@ -111,7 +108,7 @@ pub async fn start(
     }
 
     if let Some(exit_error) = exit_error {
-        return Err(CliError::StartErr(exit_error.to_string()));
+        return Err(exit_error).context("Failed to start CLI");
     }
 
     let status = SessionStatus {
@@ -223,7 +220,7 @@ fn spawn_display_thread(
     })
 }
 
-fn set_linkup_env(state: LocalState) -> Result<(), CliError> {
+fn set_linkup_env(state: LocalState) -> Result<()> {
     // Set env vars to linkup
     for service in &state.services {
         if let Some(d) = &service.directory {
@@ -238,7 +235,7 @@ fn load_and_save_state(
     config_arg: &Option<String>,
     no_tunnel: bool,
     is_paid: bool,
-) -> Result<LocalState, CliError> {
+) -> Result<LocalState> {
     let previous_state = LocalState::load();
     let config_path = config_path(config_arg)?;
     let input_config = get_config(&config_path)?;
@@ -260,35 +257,24 @@ fn load_and_save_state(
     Ok(state)
 }
 
-fn set_service_env(directory: String, config_path: String) -> Result<(), CliError> {
-    let config_dir = Path::new(&config_path).parent().ok_or_else(|| {
-        CliError::SetServiceEnv(
-            directory.clone(),
-            "config_path does not have a parent directory".to_string(),
-        )
-    })?;
+fn set_service_env(directory: String, config_path: String) -> Result<()> {
+    let config_dir = Path::new(&config_path)
+        .parent()
+        .with_context(|| format!("config_path '{directory}' does not have a parent directory"))?;
 
     let service_path = PathBuf::from(config_dir).join(&directory);
 
-    let dev_env_files_result = fs::read_dir(service_path);
-    let dev_env_files: Vec<_> = match dev_env_files_result {
-        Ok(entries) => entries
-            .filter_map(Result::ok)
-            .filter(|entry| {
-                entry.file_name().to_string_lossy().ends_with(".linkup")
-                    && entry.file_name().to_string_lossy().starts_with(".env.")
-            })
-            .collect(),
-        Err(e) => {
-            return Err(CliError::SetServiceEnv(
-                directory.clone(),
-                format!("Failed to read directory: {}", e),
-            ))
-        }
-    };
+    let dev_env_files: Vec<_> = fs::read_dir(&service_path)
+        .with_context(|| format!("Failed to read service directory {:?}", &service_path))?
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry.file_name().to_string_lossy().ends_with(".linkup")
+                && entry.file_name().to_string_lossy().starts_with(".env.")
+        })
+        .collect();
 
     if dev_env_files.is_empty() {
-        return Err(CliError::NoDevEnv(directory));
+        return Err(anyhow!("No dev env files found on {:?}", directory));
     }
 
     for dev_env_file in dev_env_files {

--- a/linkup-cli/src/commands/status.rs
+++ b/linkup-cli/src/commands/status.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use colored::{ColoredString, Colorize};
 use crossterm::{cursor, execute, style::Print, terminal};
 use linkup::{get_additional_headers, HeaderMap, StorableDomain, TargetService};
@@ -12,7 +13,7 @@ use std::{
 
 use crate::{
     local_config::{LocalService, LocalState, ServiceTarget},
-    services, CliError,
+    services, Result,
 };
 
 const LOADING_CHARS: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
@@ -29,7 +30,7 @@ pub struct Args {
     all: bool,
 }
 
-pub fn status(args: &Args) -> Result<(), CliError> {
+pub fn status(args: &Args) -> anyhow::Result<()> {
     // TODO(augustocesar)[2024-10-28]: Remove --all/-a in a future release.
     // Do not print the warning in case of JSON so it doesn't break any usage if the result of the command
     // is passed on to somewhere else.
@@ -39,7 +40,7 @@ pub fn status(args: &Args) -> Result<(), CliError> {
         println!("{}", warning.yellow());
     }
 
-    let state = LocalState::load()?;
+    let state = LocalState::load().context("Failed to load local state")?;
     let linkup_services = linkup_services(&state);
     let all_services = state.services.into_iter().chain(linkup_services);
 

--- a/linkup-cli/src/commands/stop.rs
+++ b/linkup-cli/src/commands/stop.rs
@@ -1,14 +1,16 @@
 use std::fs::{self};
 use std::path::{Path, PathBuf};
 
+use anyhow::Context;
+
 use crate::env_files::clear_env_file;
 use crate::local_config::LocalState;
-use crate::{services, CliError};
+use crate::{services, Result};
 
 #[derive(clap::Args)]
 pub struct Args {}
 
-pub fn stop(_args: &Args, clear_env: bool) -> Result<(), CliError> {
+pub fn stop(_args: &Args, clear_env: bool) -> Result<()> {
     match (LocalState::load(), clear_env) {
         (Ok(state), true) => {
             // Reset env vars back to what they were before
@@ -39,29 +41,18 @@ pub fn stop(_args: &Args, clear_env: bool) -> Result<(), CliError> {
     Ok(())
 }
 
-fn remove_service_env(directory: String, config_path: String) -> Result<(), CliError> {
-    let config_dir = Path::new(&config_path).parent().ok_or_else(|| {
-        CliError::SetServiceEnv(
-            directory.clone(),
-            "config_path does not have a parent directory".to_string(),
-        )
-    })?;
+fn remove_service_env(directory: String, config_path: String) -> Result<()> {
+    let config_dir = Path::new(&config_path)
+        .parent()
+        .with_context(|| format!("config_path '{directory}' does not have a parent directory"))?;
 
     let service_path = PathBuf::from(config_dir).join(&directory);
 
-    let env_files_result = fs::read_dir(service_path);
-    let env_files: Vec<_> = match env_files_result {
-        Ok(entries) => entries
-            .filter_map(Result::ok)
-            .filter(|entry| entry.file_name().to_string_lossy().starts_with(".env"))
-            .collect(),
-        Err(e) => {
-            return Err(CliError::SetServiceEnv(
-                directory.clone(),
-                format!("Failed to read directory: {}", e),
-            ))
-        }
-    };
+    let env_files: Vec<_> = fs::read_dir(&service_path)
+        .with_context(|| format!("Failed to read service directory {:?}", &service_path))?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with(".env"))
+        .collect();
 
     for env_file in env_files {
         let env_path = env_file.path();

--- a/linkup-cli/src/commands/uninstall.rs
+++ b/linkup-cli/src/commands/uninstall.rs
@@ -2,14 +2,14 @@ use std::{fs, process};
 
 use crate::{
     commands::{self},
-    linkup_dir_path, linkup_exe_path, CliError, InstallationMethod,
+    linkup_dir_path, linkup_exe_path, InstallationMethod, Result,
 };
 
 #[derive(clap::Args)]
 pub struct Args {}
 
 #[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
-pub async fn uninstall(_args: &Args, config_arg: &Option<String>) -> Result<(), CliError> {
+pub async fn uninstall(_args: &Args, config_arg: &Option<String>) -> Result<()> {
     commands::stop(&commands::StopArgs {}, true)?;
 
     #[cfg(target_os = "macos")]
@@ -27,10 +27,10 @@ pub async fn uninstall(_args: &Args, config_arg: &Option<String>) -> Result<(), 
         }
     }
 
-    let exe_path = linkup_exe_path();
+    let exe_path = linkup_exe_path()?;
 
     log::debug!("Linkup exe path: {:?}", &exe_path);
-    match InstallationMethod::current() {
+    match InstallationMethod::current()? {
         InstallationMethod::Brew => {
             log::debug!("Uninstalling linkup from Homebrew");
 

--- a/linkup-cli/src/commands/update.rs
+++ b/linkup-cli/src/commands/update.rs
@@ -1,4 +1,4 @@
-use crate::{current_version, linkup_exe_path, release, CliError, InstallationMethod};
+use crate::{current_version, linkup_exe_path, release, InstallationMethod, Result};
 use std::fs;
 
 #[derive(clap::Args)]
@@ -8,7 +8,7 @@ pub struct Args {
     skip_cache: bool,
 }
 
-pub async fn update(args: &Args) -> Result<(), CliError> {
+pub async fn update(args: &Args) -> Result<()> {
     if args.skip_cache {
         log::debug!("Clearing cache to force a new check for the latest version.");
 
@@ -19,7 +19,7 @@ pub async fn update(args: &Args) -> Result<(), CliError> {
         Some(update) => {
             let new_linkup_path = update.linkup.download_decompressed("linkup").await.unwrap();
 
-            let current_linkup_path = linkup_exe_path();
+            let current_linkup_path = linkup_exe_path()?;
             let bkp_linkup_path = current_linkup_path.with_extension("bkp");
 
             fs::rename(&current_linkup_path, &bkp_linkup_path)
@@ -43,9 +43,9 @@ pub async fn new_version_available() -> bool {
         .is_some()
 }
 
-pub fn update_command() -> String {
-    match InstallationMethod::current() {
-        InstallationMethod::Brew => "brew upgrade linkup".to_string(),
-        InstallationMethod::Manual | InstallationMethod::Cargo => "linkup update".to_string(),
+pub fn update_command() -> Result<String> {
+    match InstallationMethod::current()? {
+        InstallationMethod::Brew => Ok("brew upgrade linkup".to_string()),
+        InstallationMethod::Manual | InstallationMethod::Cargo => Ok("linkup update".to_string()),
     }
 }

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -1,9 +1,11 @@
 use std::{env, fs, io::ErrorKind, path::PathBuf};
 
+use anyhow::{anyhow, Context};
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 use thiserror::Error;
 
+pub use anyhow::Result;
 pub use linkup::Version;
 
 mod commands;
@@ -25,22 +27,22 @@ pub enum InstallationMethod {
 }
 
 impl InstallationMethod {
-    fn current() -> Self {
-        for component in linkup_exe_path().components() {
+    fn current() -> Result<Self> {
+        for component in linkup_exe_path()?.components() {
             if component.as_os_str() == "Cellar" {
-                return Self::Brew;
+                return Ok(Self::Brew);
             } else if component.as_os_str() == ".cargo" {
-                return Self::Cargo;
+                return Ok(Self::Cargo);
             }
         }
 
-        Self::Manual
+        Ok(Self::Manual)
     }
 }
 
-pub fn linkup_exe_path() -> PathBuf {
-    fs::canonicalize(std::env::current_exe().expect("current exe to be accessible"))
-        .expect("exe path to be valid")
+pub fn linkup_exe_path() -> Result<PathBuf> {
+    fs::canonicalize(std::env::current_exe().context("Failed to get the current executable")?)
+        .context("Failed to canonicalize the executable path")
 }
 
 pub fn linkup_dir_path() -> PathBuf {
@@ -80,11 +82,11 @@ fn ensure_linkup_dir() -> Result<()> {
         Ok(_) => Ok(()),
         Err(e) => match e.kind() {
             ErrorKind::AlreadyExists => Ok(()),
-            _ => Err(CliError::BadConfig(format!(
+            _ => Err(anyhow!(
                 "Could not create linkup dir at {}: {}",
                 path.display(),
                 e
-            ))),
+            )),
         },
     }
 }
@@ -120,72 +122,10 @@ fn sudo_su() -> Result<()> {
         .status()?;
 
     if !status.success() {
-        return Err(CliError::StartErr("failed to sudo".to_string()));
+        return Err(anyhow!("Failed to sudo"));
     }
 
     Ok(())
-}
-
-pub type Result<T> = std::result::Result<T, CliError>;
-
-#[derive(Error, Debug)]
-pub enum CliError {
-    #[error("no valid state file: {0}")]
-    NoState(String),
-    #[error("there was a problem with the provided config: {0}")]
-    BadConfig(String),
-    #[error("no valid config file provided: {0}")]
-    NoConfig(String),
-    #[error("a service directory was provided that contained no .env.*.linkup file: {0}")]
-    NoDevEnv(String),
-    #[error("couldn't set env for service {0}: {1}")]
-    SetServiceEnv(String, String),
-    #[error("couldn't remove env for service {0}: {1}")]
-    RemoveServiceEnv(String, String),
-    #[error("could not save statefile: {0}")]
-    SaveState(String),
-    #[error("could not start local server: {0}")]
-    StartLocalServer(String),
-    #[error("could not start local tunnel: {0}")]
-    StartLocalTunnel(String),
-    #[error("linkup component did not start in time: {0}")]
-    StartLinkupTimeout(String),
-    #[error("could not start DNSMasq: {0}")]
-    StartDNSMasq(String),
-    #[error("could not load config to {0}: {1}")]
-    LoadConfig(String, String),
-    #[error("could not start: {0}")]
-    StartErr(String),
-    #[error("could not stop: {0}")]
-    StopErr(String),
-    #[error("could not get status: {0}")]
-    StatusErr(String),
-    #[error("no such service: {0}")]
-    NoSuchService(String),
-    #[error("failed to install local dns: {0}")]
-    LocalDNSInstall(String),
-    #[error("failed to uninstall local dns: {0}")]
-    LocalDNSUninstall(String),
-    #[error("failed to write file: {0}")]
-    WriteFile(String),
-    #[error("failed to reboot dnsmasq: {0}")]
-    RebootDNSMasq(String),
-    #[error("--no-tunnel does not work without `local-dns`")]
-    NoTunnelWithoutLocalDns,
-    #[error("could not get env var: {0}")]
-    GetEnvVar(String),
-    #[error("HTTP error: {0}")]
-    HttpErr(String),
-    #[error("could not parse: {0}. {1}")]
-    ParseErr(String, String),
-    #[error("{0}: {1}")]
-    FileErr(String, String),
-    #[error("{0}")]
-    IOError(#[from] std::io::Error),
-    #[error("{0}")]
-    WorkerClientErr(#[from] worker_client::Error),
-    #[error("{0}")]
-    DeployErr(#[from] commands::deploy::DeployError),
 }
 
 #[derive(Error, Debug)]
@@ -267,7 +207,7 @@ enum Commands {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> anyhow::Result<()> {
     env_logger::init();
 
     let cli = Cli::parse();
@@ -277,13 +217,22 @@ async fn main() -> Result<()> {
     if !matches!(cli.command, Commands::Update(_))
         && commands::update::new_version_available().await
     {
-        let message = format!(
-            "⚠️ New version of linkup is available! Run `{}` to update it.",
-            commands::update::update_command()
-        )
-        .yellow();
+        match commands::update::update_command() {
+            Ok(update_command) => {
+                let message = format!(
+                    "⚠️ New version of linkup is available! Run `{update_command}` to update it."
+                )
+                .yellow();
 
-        println!("{}", message);
+                println!("{}", message);
+            }
+            Err(error) => {
+                // TODO(augustoccesar)[2025-03-26]: This should probably be an error log, but for now since the logs
+                //   are not behaving the way that we want them to, keep as a warning. Will revisit this once starts
+                //   looking into tracing.
+                log::warn!("Failed to resolve the update command to display to user: {error}");
+            }
+        }
     }
 
     match &cli.command {
@@ -301,7 +250,7 @@ async fn main() -> Result<()> {
         Commands::Server(args) => commands::server(args, &linkup_certs_dir_path()).await,
         Commands::Uninstall(args) => commands::uninstall(args, &cli.config).await,
         Commands::Update(args) => commands::update(args).await,
-        Commands::Deploy(args) => commands::deploy(args).await.map_err(CliError::from),
-        Commands::Destroy(args) => commands::destroy(args).await.map_err(CliError::from),
+        Commands::Deploy(args) => commands::deploy(args).await,
+        Commands::Destroy(args) => commands::destroy(args).await,
     }
 }

--- a/linkup-cli/src/services/dnsmasq.rs
+++ b/linkup-cli/src/services/dnsmasq.rs
@@ -9,6 +9,7 @@ use crate::{
     commands::local_dns,
     linkup_dir_path, linkup_file_path,
     local_config::{self, LocalState},
+    Result,
 };
 
 use super::{get_running_pid, stop_pid_file, BackgroundService, Pid, PidError, Signal};
@@ -65,7 +66,7 @@ pid-file={}\n",
         Ok(())
     }
 
-    fn start(&self) -> Result<(), Error> {
+    fn start(&self) -> Result<()> {
         log::debug!("Starting {}", Self::NAME);
 
         Command::new("dnsmasq")
@@ -95,14 +96,14 @@ pid-file={}\n",
     }
 }
 
-impl BackgroundService<Error> for Dnsmasq {
+impl BackgroundService for Dnsmasq {
     const NAME: &str = "Dnsmasq";
 
     async fn run_with_progress(
         &self,
         state: &mut LocalState,
         status_sender: std::sync::mpsc::Sender<super::RunUpdate>,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         if !self.should_start(state) {
             self.notify_update_with_details(
                 &status_sender,
@@ -132,7 +133,7 @@ impl BackgroundService<Error> for Dnsmasq {
                 "Failed to setup",
             );
 
-            return Err(e);
+            return Err(e.into());
         }
 
         if let Err(e) = self.start() {

--- a/linkup-cli/src/services/mod.rs
+++ b/linkup-cli/src/services/mod.rs
@@ -49,14 +49,14 @@ pub struct RunUpdate {
     pub details: Option<String>,
 }
 
-pub trait BackgroundService<E: std::error::Error> {
+pub trait BackgroundService {
     const NAME: &str;
 
     async fn run_with_progress(
         &self,
         local_state: &mut LocalState,
         status_sender: sync::mpsc::Sender<RunUpdate>,
-    ) -> Result<(), E>;
+    ) -> anyhow::Result<()>;
 
     fn notify_update(&self, status_sender: &sync::mpsc::Sender<RunUpdate>, status: RunStatus) {
         status_sender


### PR DESCRIPTION
### Description

This changes to use [anyhow](https://docs.rs/anyhow/latest/anyhow/) instead of a "global" error enum. This does not fully tackle adding context to places where errors happens, but more replace on places where it was straightforward to change one for the other.

As a follow-up, should go on places that we currently have `.unwrap()`, `.expect()` and some `?` to add `.context()/.with_context()` to them.

### Difference of output
Before these changes, running `linkup status` before a state exists (running `linkup start`) would result on this error:
```
Error: NoState("No such file or directory (os error 2)")
```

With these changes, this is the error:
```
Error: Failed to load local state

Caused by:
    0: Failed to read state file on "/Users/username/.linkup/state"
    1: No such file or directory (os error 2)
```