### PR TITLE
feat(cli): support stable<->beta updates from the CLI

### DIFF
--- a/linkup-cli/src/release.rs
+++ b/linkup-cli/src/release.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use flate2::read::GzDecoder;
+use linkup::VersionChannel;
 use reqwest::header::HeaderValue;
 use serde::{Deserialize, Serialize};
 use tar::Archive;
@@ -12,7 +13,8 @@ use url::Url;
 
 use crate::{linkup_file_path, Version};
 
-const CACHED_LATEST_RELEASE_FILE: &str = "latest_release.json";
+const CACHED_LATEST_STABLE_RELEASE_FILE: &str = "latest_release_stable.json";
+const CACHED_LATEST_BETA_RELEASE_FILE: &str = "latest_release_beta.json";
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -125,29 +127,56 @@ pub struct Update {
     pub linkup: Asset,
 }
 
-pub async fn available_update(current_version: &Version) -> Option<Update> {
+pub async fn available_update(
+    current_version: &Version,
+    desired_channel: Option<linkup::VersionChannel>,
+) -> Option<Update> {
     let os = env::consts::OS;
     let arch = env::consts::ARCH;
 
-    let latest_release = match cached_latest_release().await {
-        Some(cached_latest_release) => cached_latest_release.release,
+    let channel = desired_channel.unwrap_or_else(|| current_version.channel());
+    log::debug!("Looking for available update on '{channel}' channel.");
+
+    let latest_release = match cached_latest_release(&channel).await {
+        Some(cached_latest_release) => {
+            let release = cached_latest_release.release;
+
+            log::debug!("Found cached release: {}", release.version);
+
+            release
+        }
         None => {
-            let release = if current_version.is_beta() {
-                fetch_beta_release().await
-            } else {
-                fetch_stable_release().await
+            log::debug!("No cached release found. Fetching from remote...");
+
+            let release = match channel {
+                linkup::VersionChannel::Stable => fetch_stable_release().await,
+                linkup::VersionChannel::Beta => fetch_beta_release().await,
             };
 
             let release = match release {
-                Ok(Some(release)) => release,
-                Ok(None) => return None,
+                Ok(Some(release)) => {
+                    log::debug!("Found release {} on channel '{channel}'.", release.version);
+
+                    release
+                }
+                Ok(None) => {
+                    log::debug!("No release found on remote for channel '{channel}'");
+
+                    return None;
+                }
                 Err(error) => {
                     log::error!("Failed to fetch the latest release: {}", error);
+
                     return None;
                 }
             };
 
-            match fs::File::create(linkup_file_path(CACHED_LATEST_RELEASE_FILE)) {
+            let cache_file = match channel {
+                VersionChannel::Stable => CACHED_LATEST_STABLE_RELEASE_FILE,
+                VersionChannel::Beta => CACHED_LATEST_BETA_RELEASE_FILE,
+            };
+
+            match fs::File::create(linkup_file_path(cache_file)) {
                 Ok(new_file) => {
                     let release_cache = CachedLatestRelease {
                         time: now(),
@@ -182,7 +211,10 @@ pub async fn available_update(current_version: &Version) -> Option<Update> {
         }
     };
 
-    if current_version >= &latest_version {
+    // Only check the version if the channel is the same.
+    if current_version.channel() == latest_version.channel() && current_version >= &latest_version {
+        log::debug!("Current version ({current_version}) is newer than latest ({latest_version}).");
+
         return None;
     }
 
@@ -251,8 +283,13 @@ pub async fn fetch_beta_release() -> Result<Option<Release>, reqwest::Error> {
     Ok(beta_release)
 }
 
-async fn cached_latest_release() -> Option<CachedLatestRelease> {
-    let path = linkup_file_path(CACHED_LATEST_RELEASE_FILE);
+async fn cached_latest_release(channel: &VersionChannel) -> Option<CachedLatestRelease> {
+    let file = match channel {
+        VersionChannel::Stable => CACHED_LATEST_STABLE_RELEASE_FILE,
+        VersionChannel::Beta => CACHED_LATEST_STABLE_RELEASE_FILE,
+    };
+
+    let path = linkup_file_path(file);
     if !path.exists() {
         return None;
     }
@@ -294,11 +331,14 @@ async fn cached_latest_release() -> Option<CachedLatestRelease> {
 }
 
 pub fn clear_cache() {
-    let path = linkup_file_path(CACHED_LATEST_RELEASE_FILE);
-
-    if path.exists() {
-        if let Err(error) = fs::remove_file(path) {
-            log::error!("Failed to delete latest release cache file: {}", error);
+    for path in [
+        linkup_file_path(CACHED_LATEST_STABLE_RELEASE_FILE),
+        linkup_file_path(CACHED_LATEST_BETA_RELEASE_FILE),
+    ] {
+        if path.exists() {
+            if let Err(error) = fs::remove_file(&path) {
+                log::error!("Failed to delete release cache file {path:?}: {error}");
+            }
         }
     }
 }

--- a/linkup/src/versioning.rs
+++ b/linkup/src/versioning.rs
@@ -6,6 +6,21 @@ pub enum VersionError {
     Parsing(String),
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum VersionChannel {
+    Stable,
+    Beta,
+}
+
+impl Display for VersionChannel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VersionChannel::Stable => write!(f, "stable"),
+            VersionChannel::Beta => write!(f, "beta"),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Version {
     pub major: u16,
@@ -15,12 +30,11 @@ pub struct Version {
 }
 
 impl Version {
-    pub fn is_beta(&self) -> bool {
-        if let Some(pre_release) = &self.pre_release {
-            return pre_release.starts_with("next-");
+    pub fn channel(&self) -> VersionChannel {
+        match &self.pre_release {
+            Some(_) => VersionChannel::Beta,
+            None => VersionChannel::Stable,
         }
-
-        false
     }
 }
 

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -11,7 +11,7 @@ use http_error::HttpError;
 use kv_store::CfWorkerStringStore;
 use linkup::{
     allow_all_cors, get_additional_headers, get_target_service, CreatePreviewRequest, NameKind,
-    Session, SessionAllocator, UpdateSessionRequest, Version,
+    Session, SessionAllocator, UpdateSessionRequest, Version, VersionChannel,
 };
 use serde::{Deserialize, Serialize};
 use tower_service::Service;
@@ -542,7 +542,7 @@ async fn authenticate(
                 Some(value) => match Version::try_from(value.to_str().unwrap()) {
                     Ok(client_version) => {
                         if client_version < state.min_supported_client_version
-                            && !client_version.is_beta()
+                            && client_version.channel() != VersionChannel::Beta
                         {
                             return (
                                     StatusCode::UNAUTHORIZED,


### PR DESCRIPTION
This allows users to explicitly choose which channel to update to. So a user in a beta version can update to the stable and vice versa.

Related to SHIP-2057