### PR TITLE
feat: rely on command environment instead of PID file

### DIFF
--- a/linkup-cli/src/commands/server.rs
+++ b/linkup-cli/src/commands/server.rs
@@ -1,13 +1,9 @@
 use crate::Result;
 use linkup::MemoryStringStore;
-use std::fs;
 use tokio::select;
 
 #[derive(clap::Args)]
 pub struct Args {
-    #[arg(long)]
-    pidfile: String,
-
     #[command(subcommand)]
     server_kind: ServerKind,
 }
@@ -28,9 +24,6 @@ pub enum ServerKind {
 }
 
 pub async fn server(args: &Args) -> Result<()> {
-    let pid = std::process::id();
-    fs::write(&args.pidfile, pid.to_string())?;
-
     match &args.server_kind {
         #[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
         ServerKind::LocalWorker { certs_dir } => {

--- a/linkup-cli/src/commands/stop.rs
+++ b/linkup-cli/src/commands/stop.rs
@@ -5,6 +5,7 @@ use anyhow::Context;
 
 use crate::env_files::clear_env_file;
 use crate::local_config::LocalState;
+use crate::services::{stop_service, BackgroundService};
 use crate::{services, Result};
 
 #[derive(clap::Args)]
@@ -31,10 +32,10 @@ pub fn stop(_args: &Args, clear_env: bool) -> Result<()> {
         }
     }
 
-    services::LocalServer::new().stop();
-    services::CloudflareTunnel::new().stop();
+    stop_service(services::LocalServer::ID);
+    stop_service(services::CloudflareTunnel::ID);
     #[cfg(target_os = "macos")]
-    services::LocalDnsServer::new().stop();
+    stop_service(services::LocalDnsServer::ID);
 
     println!("Stopped linkup");
 

--- a/linkup-cli/src/services/cloudflare_tunnel.rs
+++ b/linkup-cli/src/services/cloudflare_tunnel.rs
@@ -19,7 +19,7 @@ use url::Url;
 
 use crate::{linkup_file_path, local_config::LocalState, worker_client::WorkerClient, Result};
 
-use super::{get_running_pid, stop_pid_file, BackgroundService, Pid, PidError, Signal};
+use super::{find_service_pid, BackgroundService, PidError};
 
 #[derive(thiserror::Error, Debug)]
 #[allow(dead_code)]
@@ -91,6 +91,7 @@ impl CloudflareTunnel {
             .stdout(stdout_file)
             .stderr(stderr_file)
             .stdin(Stdio::null())
+            .env("LINKUP_SERVICE_ID", Self::ID)
             .args([
                 "tunnel",
                 "--pidfile",
@@ -102,16 +103,6 @@ impl CloudflareTunnel {
             .spawn()?;
 
         Ok(tunnel_url)
-    }
-
-    pub fn stop(&self) {
-        log::debug!("Stopping {}", Self::NAME);
-
-        stop_pid_file(&self.pidfile_path, Signal::Interrupt);
-    }
-
-    pub fn running_pid(&self) -> Option<Pid> {
-        get_running_pid(&self.pidfile_path)
     }
 
     async fn dns_propagated(&self, tunnel_url: &Url) -> bool {
@@ -152,6 +143,7 @@ impl CloudflareTunnel {
 }
 
 impl BackgroundService for CloudflareTunnel {
+    const ID: &str = "cloudflare-tunnel";
     const NAME: &str = "Cloudflare Tunnel";
 
     async fn run_with_progress(
@@ -179,7 +171,7 @@ impl BackgroundService for CloudflareTunnel {
             return Err(Error::InvalidSessionName(state.linkup.session_name.clone()).into());
         }
 
-        if self.running_pid().is_some() {
+        if find_service_pid(Self::ID).is_some() {
             self.notify_update_with_details(
                 &status_sender,
                 super::RunStatus::Started,
@@ -358,4 +350,33 @@ fn create_config_yml(tunnel_id: &str) -> Result<(), Error> {
     fs::write(dir_path.join("config.yml"), serialized)?;
 
     Ok(())
+}
+
+// Get the pid from a pidfile, but only return Some in case the pidfile is valid and the written pid on the file
+// is running.
+fn get_running_pid(file_path: &Path) -> Option<super::Pid> {
+    let pid = match get_pid(file_path) {
+        Ok(pid) => pid,
+        Err(_) => return None,
+    };
+
+    super::system().process(pid).map(|_| pid)
+}
+
+fn get_pid(file_path: &Path) -> Result<super::Pid, PidError> {
+    if let Err(e) = File::open(file_path) {
+        return Err(PidError::NoPidFile(e.to_string()));
+    }
+
+    match fs::read_to_string(file_path) {
+        Ok(content) => {
+            let pid_u32 = content
+                .trim()
+                .parse::<u32>()
+                .map_err(|e| PidError::BadPidFile(e.to_string()))?;
+
+            Ok(super::Pid::from_u32(pid_u32))
+        }
+        Err(e) => Err(PidError::BadPidFile(e.to_string())),
+    }
 }


### PR DESCRIPTION
Pid files haven't been very reliable for the purpose of knowing if a background service is running and what is its PID. With this new approach, we start all the background services with an extra environment variable called `LINKUP_SERVICE_ID`, which then we query for knowing if the service is running and what is its PID.

Closes SHIP-2049
Related to SHIP-2057