### PR TITLE
fix: local dns server issues

### DIFF
--- a/linkup-cli/src/commands/health.rs
+++ b/linkup-cli/src/commands/health.rs
@@ -126,19 +126,23 @@ impl BackgroudServices {
         };
 
         #[cfg(target_os = "macos")]
-        let dns_server =
-            if local_dns::is_installed(&crate::local_config::managed_domains(Some(state), &None)) {
-                match find_service_pid(services::LocalDnsServer::ID) {
-                    Some(pid) => {
-                        managed_pids.push(pid);
+        let dns_server = match find_service_pid(services::LocalDnsServer::ID) {
+            Some(pid) => {
+                managed_pids.push(pid);
 
-                        BackgroundServiceHealth::Running(pid.as_u32())
-                    }
-                    None => BackgroundServiceHealth::Stopped,
+                BackgroundServiceHealth::Running(pid.as_u32())
+            }
+            None => {
+                if local_dns::is_installed(&crate::local_config::managed_domains(
+                    Some(state),
+                    &None,
+                )) {
+                    BackgroundServiceHealth::Stopped
+                } else {
+                    BackgroundServiceHealth::NotInstalled
                 }
-            } else {
-                BackgroundServiceHealth::NotInstalled
-            };
+            }
+        };
 
         Self {
             linkup_server,

--- a/linkup-cli/src/services/local_dns_server.rs
+++ b/linkup-cli/src/services/local_dns_server.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::Context;
 
-use crate::{linkup_file_path, local_config::LocalState, Result};
+use crate::{commands::local_dns, linkup_file_path, local_config::LocalState, Result};
 
 use super::BackgroundService;
 
@@ -69,6 +69,16 @@ impl BackgroundService for LocalDnsServer {
 
         let session_name = state.linkup.session_name.clone();
         let domains = state.domain_strings();
+
+        if !local_dns::is_installed(&domains) {
+            self.notify_update_with_details(
+                &status_sender,
+                super::RunStatus::Skipped,
+                "Not installed",
+            );
+
+            return Ok(());
+        }
 
         if let Err(e) = self.start(&session_name, &domains) {
             self.notify_update_with_details(


### PR DESCRIPTION
Fixes:
- (6d6b8463e3865b8c1477115c4e0fdc5d35e23a30) Change health check order. Since the check for installation is based on resolvers files existing, not on a binary existing (for example), theoretically it can be actually running even though there are no resolvers. So this will show and be managed (stop) correctly in case that is true.
- (e3317cf8306273fd2b43f7731dfc73e7804cd55e) Only start Local DNS if local-dns is installed.

Related to SHIP-2057