### PR TITLE
fix: possible orphans ignore linkup folder path if is in env variable

### DIFF
--- a/linkup-cli/src/commands/health.rs
+++ b/linkup-cli/src/commands/health.rs
@@ -156,7 +156,7 @@ impl BackgroudServices {
 }
 
 fn find_potential_orphan_processes(managed_pids: Vec<services::Pid>) -> Vec<OrphanProcess> {
-    let env_var_format = Regex::new(r"[A-Z_][A-Z0-9_]*=.*").unwrap();
+    let env_var_format = Regex::new(r"^[A-Z_][A-Z0-9_]*=.*$").unwrap();
 
     let current_pid = sysinfo::get_current_pid().unwrap();
     let mut orphans = Vec::new();
@@ -172,7 +172,7 @@ fn find_potential_orphan_processes(managed_pids: Vec<services::Pid>) -> Vec<Orph
 
             if env_var_format.is_match(&part_string) {
                 part_string = part_string
-                    .replace(linkup_dir_path().to_str().unwrap(), "")
+                    .replace(&linkup_dir_path().to_string_lossy().to_string(), "")
                     .into();
             }
 


### PR DESCRIPTION
Some processes add the linkup bin folder somewhere on their command. Sometimes as environment variable.

For example, `bundle exec ...` load the users `PATH` into a variable `BUNDLER_ORIG_PATH`, which contains the path to the linkup bin folder. These should not be considered possible orphan processes, but they are at the moment.

Also now maxing the size of the output of the orphan commands to be 120 characters to avoid huge outputs when the list of arguments are too long.

Related to SHIP-2057