### PR TITLE
feat: improve feedback for local and remote commands

### DIFF
--- a/linkup-cli/src/commands/local.rs
+++ b/linkup-cli/src/commands/local.rs
@@ -1,7 +1,9 @@
 use anyhow::anyhow;
+use colored::Colorize;
 
 use crate::{
     local_config::{upload_state, LocalState, ServiceTarget},
+    services::{self, find_service_pid, BackgroundService},
     Result,
 };
 
@@ -21,6 +23,26 @@ pub struct Args {
 pub async fn local(args: &Args) -> Result<()> {
     if args.service_names.is_empty() && !args.all {
         return Err(anyhow!("No service names provided"));
+    }
+
+    if !LocalState::exists() {
+        println!(
+            "{}",
+            "Seems like you don't have any state yet to point to local.".yellow()
+        );
+        println!("{}", "Have you run `linkup start` at least once?".yellow());
+
+        return Ok(());
+    }
+
+    if find_service_pid(services::LocalServer::ID).is_none() {
+        println!(
+            "{}",
+            "Seems like your local Linkup server is not running. Please run `linkup start` first."
+                .yellow()
+        );
+
+        return Ok(());
     }
 
     let mut state = LocalState::load()?;

--- a/linkup-cli/src/commands/remote.rs
+++ b/linkup-cli/src/commands/remote.rs
@@ -1,9 +1,11 @@
 use crate::{
     local_config::{upload_state, LocalState, ServiceTarget},
+    services::{self, find_service_pid, BackgroundService},
     Result,
 };
 
 use anyhow::anyhow;
+use colored::Colorize;
 
 #[derive(clap::Args)]
 pub struct Args {
@@ -23,7 +25,27 @@ pub async fn remote(args: &Args) -> Result<()> {
         return Err(anyhow!("No service names provided"));
     }
 
+    if !LocalState::exists() {
+        println!(
+            "{}",
+            "Seems like you don't have any state yet to point to remote.".yellow()
+        );
+        println!("{}", "Have you run `linkup start` at least once?".yellow());
+
+        return Ok(());
+    }
+
     let mut state = LocalState::load()?;
+
+    if find_service_pid(services::LocalServer::ID).is_none() {
+        println!(
+            "{}",
+            "Seems like your local Linkup server is not running. Please run `linkup start` first."
+                .yellow()
+        );
+
+        return Ok(());
+    }
 
     if args.all {
         for service in state.services.iter_mut() {

--- a/linkup-cli/src/local_config.rs
+++ b/linkup-cli/src/local_config.rs
@@ -74,6 +74,10 @@ impl LocalState {
             .map(|storable_domain| storable_domain.domain.clone())
             .collect::<Vec<String>>()
     }
+
+    pub fn exists() -> bool {
+        linkup_file_path(LINKUP_STATE_FILE).exists()
+    }
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]


### PR DESCRIPTION
When trying to run `local` or `remote` when either have never ran `start` or when the local server is not running, the error that the users face is not great.
This should improve the understanding of what is wrong.

### Current errors

When calling before an initial `start`:
```
Error: Failed to read state file
```

When calling with local server stopped:
```
Error: WorkerClientErr(Reqwest(reqwest::Error { kind: Request, url: "http://localhost:8080/linkup/local-session", source: hyper_util::client::legacy::Error(Connect, ConnectError("tcp connect error", Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })) }))
```

### New errors
When calling before an initial `start`:
```
Seems like you don't have any state yet to point to local.
Have you run `linkup start` at least once?
```

When calling with local server stopped:
```
Seems like your local Linkup server is not running. Please run `linkup start` first.
```

Closes SHIP-2024