### PR TITLE
feat(cli): set port binding capability on binary for Linux

### DIFF
--- a/linkup-cli/install.py
+++ b/linkup-cli/install.py
@@ -204,7 +204,7 @@ def download_and_extract(user_os: OS, user_arch: Arch, channel: Channel, release
 
     print(f"Decompressing {local_tar_path}")
     with tarfile.open(local_tar_path, "r:gz") as tar:
-        tar.extractall(path="/tmp")
+        tar.extractall(path="/tmp", filter="data")
 
     LINKUP_BIN_PATH.mkdir(parents=True, exist_ok=True)
     linkup_bin_path = LINKUP_BIN_PATH / "linkup"

--- a/linkup-cli/install.py
+++ b/linkup-cli/install.py
@@ -212,7 +212,7 @@ def download_and_extract(user_os: OS, user_arch: Arch, channel: Channel, release
     os.chmod(linkup_bin_path, 0o755)
 
     if user_os.Linux:
-        subprocess.run(["sudo", "setcap", "'cap_net_bind_service=+ep'", linkup_bin_path])
+        subprocess.run(["sudo", "setcap", "'cap_net_bind_service=+ep'", f"{linkup_bin_path}"])
 
     print(f"Linkup installed at {LINKUP_BIN_PATH / 'linkup'}")
     local_tar_path.unlink()

--- a/linkup-cli/install.py
+++ b/linkup-cli/install.py
@@ -12,6 +12,7 @@ import json
 import os
 import re
 import shutil
+import subprocess
 import tarfile
 import urllib.request
 from dataclasses import dataclass
@@ -206,8 +207,12 @@ def download_and_extract(user_os: OS, user_arch: Arch, channel: Channel, release
         tar.extractall(path="/tmp")
 
     LINKUP_BIN_PATH.mkdir(parents=True, exist_ok=True)
-    shutil.move("/tmp/linkup", LINKUP_BIN_PATH / "linkup")
-    os.chmod(LINKUP_BIN_PATH / "linkup", 0o755)
+    linkup_bin_path = LINKUP_BIN_PATH / "linkup"
+    shutil.move("/tmp/linkup", linkup_bin_path)
+    os.chmod(linkup_bin_path, 0o755)
+
+    if user_os.Linux:
+        subprocess.run(["sudo", "setcap", "'cap_net_bind_service=+ep'", linkup_bin_path])
 
     print(f"Linkup installed at {LINKUP_BIN_PATH / 'linkup'}")
     local_tar_path.unlink()

--- a/linkup-cli/install.py
+++ b/linkup-cli/install.py
@@ -212,7 +212,7 @@ def download_and_extract(user_os: OS, user_arch: Arch, channel: Channel, release
     os.chmod(linkup_bin_path, 0o755)
 
     if user_os.Linux:
-        subprocess.run(["sudo", "setcap", "'cap_net_bind_service=+ep'", f"{linkup_bin_path}"])
+        subprocess.run(["sudo", "setcap", "cap_net_bind_service=+ep", f"{linkup_bin_path}"])
 
     print(f"Linkup installed at {LINKUP_BIN_PATH / 'linkup'}")
     local_tar_path.unlink()

--- a/linkup-cli/src/commands/health.rs
+++ b/linkup-cli/src/commands/health.rs
@@ -261,7 +261,7 @@ impl Linkup {
             }
             Err(error) => {
                 log::warn!("Failed to check capabilities: {}", error);
-                return false;
+                false
             }
         }
     }

--- a/linkup-cli/src/commands/health.rs
+++ b/linkup-cli/src/commands/health.rs
@@ -242,8 +242,8 @@ impl Linkup {
     #[cfg(target_os = "linux")]
     pub fn is_cap_set(&self) -> bool {
         let output = std::process::Command::new("getcap")
-            .stdout(std::process::Stdio::inherit())
-            .stderr(std::process::Stdio::inherit())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
             .stdin(std::process::Stdio::null())
             .args([crate::linkup_exe_path().unwrap().display().to_string()])
             .output();

--- a/linkup-cli/src/commands/health.rs
+++ b/linkup-cli/src/commands/health.rs
@@ -1,13 +1,12 @@
+use clap::crate_version;
+use colored::Colorize;
+use regex::Regex;
+use serde::Serialize;
 use std::{
     env,
     fmt::Display,
     fs::{self},
 };
-
-use clap::crate_version;
-use colored::Colorize;
-use regex::Regex;
-use serde::Serialize;
 
 use crate::{
     linkup_dir_path,
@@ -239,6 +238,33 @@ impl Linkup {
             config_content: files,
         })
     }
+
+    #[cfg(target_os = "linux")]
+    pub fn is_cap_set(&self) -> bool {
+        let output = std::process::Command::new("getcap")
+            .stdout(std::process::Stdio::inherit())
+            .stderr(std::process::Stdio::inherit())
+            .stdin(std::process::Stdio::null())
+            .args([crate::linkup_exe_path().unwrap().display().to_string()])
+            .output();
+
+        match output {
+            Ok(output) => {
+                if !output.status.success() {
+                    let error_message = String::from_utf8_lossy(&output.stderr).to_string();
+                    log::warn!("Failed to check capabilities: {}", error_message);
+                    return false;
+                }
+
+                let output_text = String::from_utf8_lossy(&output.stdout).to_string();
+                output_text.contains("cap_net_bind_service=ep")
+            }
+            Err(error) => {
+                log::warn!("Failed to check capabilities: {}", error);
+                return false;
+            }
+        }
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -357,6 +383,15 @@ impl Display for Health {
 
         writeln!(f, "{}", "Linkup:".bold().italic())?;
         writeln!(f, "  Version: {}", self.linkup.version)?;
+        #[cfg(target_os = "linux")]
+        {
+            write!(f, "  Capability set: ")?;
+            if self.linkup.is_cap_set() {
+                writeln!(f, "{}", "YES".blue())?;
+            } else {
+                writeln!(f, "{}", "NO".yellow())?;
+            }
+        }
         writeln!(
             f,
             "  Config folder location: {}",

--- a/linkup-cli/src/commands/update.rs
+++ b/linkup-cli/src/commands/update.rs
@@ -58,6 +58,22 @@ pub async fn update(args: &Args) -> Result<()> {
             fs::rename(&new_linkup_path, &current_linkup_path)
                 .expect("failed to move the new exe as the current exe");
 
+            #[cfg(target_os = "linux")]
+            {
+                println!("Linkup needs sudo access to:");
+                println!("  - Add capability to bind to port 80/443");
+                std::process::Command::new("sudo")
+                    .stdout(std::process::Stdio::inherit())
+                    .stderr(std::process::Stdio::inherit())
+                    .stdin(std::process::Stdio::null())
+                    .args([
+                        "setcap",
+                        "cap_net_bind_service=+ep",
+                        &current_linkup_path.display().to_string(),
+                    ])
+                    .spawn()?;
+            }
+
             println!("Finished update!");
         }
         None => {


### PR DESCRIPTION
**What's done**
- using `setcap` in Linux to be able to bind ports
  - for install
  - for update
- changed the Heath command to say whether the capability is set or not