### PR TITLE
feat(certificates): add self-signed certs on Ubuntu

### DIFF
--- a/linkup-cli/src/commands/local_dns.rs
+++ b/linkup-cli/src/commands/local_dns.rs
@@ -133,8 +133,11 @@ fn install_resolvers(resolve_domains: &[String]) -> Result<()> {
         }
     }
 
-    flush_dns_cache()?;
-    kill_dns_responder()?;
+    #[cfg(target_os = "macos")]
+    {
+        flush_dns_cache()?;
+        kill_dns_responder()?;
+    }
 
     Ok(())
 }
@@ -150,8 +153,11 @@ fn uninstall_resolvers(resolve_domains: &[String]) -> Result<()> {
             .with_context(|| format!("Failed to delete /etc/resolver/{domain}",))?;
     }
 
-    flush_dns_cache()?;
-    kill_dns_responder()?;
+    #[cfg(target_os = "macos")]
+    {
+        flush_dns_cache()?;
+        kill_dns_responder()?;
+    }
 
     Ok(())
 }
@@ -173,6 +179,7 @@ pub fn list_resolvers() -> std::result::Result<Vec<String>, std::io::Error> {
     Ok(resolvers)
 }
 
+#[cfg(target_os = "macos")]
 fn flush_dns_cache() -> Result<()> {
     let status_flush = Command::new("dscacheutil")
         .args(["-flushcache"])
@@ -186,6 +193,7 @@ fn flush_dns_cache() -> Result<()> {
     Ok(())
 }
 
+#[cfg(target_os = "macos")]
 fn kill_dns_responder() -> Result<()> {
     let status_kill_responder = Command::new("sudo")
         .args(["killall", "-HUP", "mDNSResponder"])

--- a/linkup-cli/src/commands/local_dns.rs
+++ b/linkup-cli/src/commands/local_dns.rs
@@ -150,11 +150,8 @@ fn uninstall_resolvers(resolve_domains: &[String]) -> Result<()> {
             .with_context(|| format!("Failed to delete /etc/resolver/{domain}",))?;
     }
 
-    #[cfg(target_os = "macos")]
-    {
-        flush_dns_cache()?;
-        kill_dns_responder()?;
-    }
+    flush_dns_cache()?;
+    kill_dns_responder()?;
 
     Ok(())
 }

--- a/linkup-cli/src/commands/local_dns.rs
+++ b/linkup-cli/src/commands/local_dns.rs
@@ -198,7 +198,7 @@ fn flush_dns_cache() -> Result<()> {
         .context("Failed to flush DNS cache")?;
 
     if !status_flush.success() {
-        return Err(anyhow!("Flushing DNS cache was unsuccessful"));
+        log::warn!("Flushing DNS cache was unsuccessful");
     }
 
     Ok(())
@@ -226,7 +226,7 @@ fn kill_dns_responder() -> Result<()> {
         .context("Failed to kill DNS responder")?;
 
     if !status_kill_responder.success() {
-        return Err(anyhow!("Killing DNS responder was unsuccessful"));
+        log::warn!("Killing DNS responder was unsuccessful");
     }
 
     Ok(())

--- a/linkup-cli/src/commands/mod.rs
+++ b/linkup-cli/src/commands/mod.rs
@@ -2,7 +2,6 @@ pub mod completion;
 pub mod deploy;
 pub mod health;
 pub mod local;
-#[cfg(target_os = "macos")]
 pub mod local_dns;
 pub mod preview;
 pub mod remote;
@@ -19,7 +18,6 @@ pub use {deploy::deploy, deploy::DeployArgs};
 pub use {deploy::destroy, deploy::DestroyArgs};
 pub use {health::health, health::Args as HealthArgs};
 pub use {local::local, local::Args as LocalArgs};
-#[cfg(target_os = "macos")]
 pub use {local_dns::local_dns, local_dns::Args as LocalDnsArgs};
 pub use {preview::preview, preview::Args as PreviewArgs};
 pub use {remote::remote, remote::Args as RemoteArgs};

--- a/linkup-cli/src/commands/server.rs
+++ b/linkup-cli/src/commands/server.rs
@@ -36,7 +36,6 @@ pub async fn server(args: &Args) -> Result<()> {
                     .unwrap();
             });
 
-            #[cfg(target_os = "macos")]
             let handler_https = {
                 use std::path::PathBuf;
 

--- a/linkup-cli/src/commands/start.rs
+++ b/linkup-cli/src/commands/start.rs
@@ -46,7 +46,6 @@ pub async fn start(args: &Args, fresh_state: bool, config_arg: &Option<String>) 
 
     let local_server = services::LocalServer::new();
     let cloudflare_tunnel = services::CloudflareTunnel::new();
-    #[cfg(target_os = "macos")]
     let local_dns_server = services::LocalDnsServer::new();
 
     let mut display_thread: Option<JoinHandle<()>> = None;
@@ -60,7 +59,6 @@ pub async fn start(args: &Args, fresh_state: bool, config_arg: &Option<String>) 
             &[
                 services::LocalServer::NAME,
                 services::CloudflareTunnel::NAME,
-                #[cfg(target_os = "macos")]
                 services::LocalDnsServer::NAME,
             ],
             status_update_channel.1,
@@ -91,16 +89,13 @@ pub async fn start(args: &Args, fresh_state: bool, config_arg: &Option<String>) 
         }
     }
 
-    #[cfg(target_os = "macos")]
-    {
-        if exit_error.is_none() {
-            match local_dns_server
-                .run_with_progress(&mut state, status_update_channel.0.clone())
-                .await
-            {
-                Ok(_) => (),
-                Err(err) => exit_error = Some(err),
-            }
+    if exit_error.is_none() {
+        match local_dns_server
+            .run_with_progress(&mut state, status_update_channel.0.clone())
+            .await
+        {
+            Ok(_) => (),
+            Err(err) => exit_error = Some(err),
         }
     }
 

--- a/linkup-cli/src/commands/stop.rs
+++ b/linkup-cli/src/commands/stop.rs
@@ -34,7 +34,6 @@ pub fn stop(_args: &Args, clear_env: bool) -> Result<()> {
 
     stop_service(services::LocalServer::ID);
     stop_service(services::CloudflareTunnel::ID);
-    #[cfg(target_os = "macos")]
     stop_service(services::LocalDnsServer::ID);
 
     println!("Stopped linkup");

--- a/linkup-cli/src/commands/uninstall.rs
+++ b/linkup-cli/src/commands/uninstall.rs
@@ -1,9 +1,8 @@
 use std::{fs, process};
 
-use crate::commands::local_dns;
-use crate::local_config::LocalState;
 use crate::{
-    commands, linkup_dir_path, linkup_exe_path, local_config, prompt, InstallationMethod, Result,
+    commands, commands::local_dns, linkup_dir_path, linkup_exe_path, local_config::managed_domains,
+    local_config::LocalState, prompt, InstallationMethod, Result,
 };
 
 #[derive(clap::Args)]
@@ -23,7 +22,7 @@ pub async fn uninstall(_args: &Args, config_arg: &Option<String>) -> Result<()> 
 
     commands::stop(&commands::StopArgs {}, true)?;
 
-    if local_dns::is_installed(&local_config::managed_domains(
+    if local_dns::is_installed(&managed_domains(
         LocalState::load().ok().as_ref(),
         config_arg,
     )) {

--- a/linkup-cli/src/commands/uninstall.rs
+++ b/linkup-cli/src/commands/uninstall.rs
@@ -1,6 +1,10 @@
 use std::{fs, process};
 
-use crate::{commands, linkup_dir_path, linkup_exe_path, prompt, InstallationMethod, Result};
+use crate::commands::local_dns;
+use crate::local_config::LocalState;
+use crate::{
+    commands, linkup_dir_path, linkup_exe_path, local_config, prompt, InstallationMethod, Result,
+};
 
 #[derive(clap::Args)]
 pub struct Args {}
@@ -19,19 +23,11 @@ pub async fn uninstall(_args: &Args, config_arg: &Option<String>) -> Result<()> 
 
     commands::stop(&commands::StopArgs {}, true)?;
 
-    #[cfg(target_os = "macos")]
-    {
-        use crate::{
-            commands::local_dns,
-            local_config::{self, LocalState},
-        };
-
-        if local_dns::is_installed(&local_config::managed_domains(
-            LocalState::load().ok().as_ref(),
-            config_arg,
-        )) {
-            local_dns::uninstall(config_arg).await?;
-        }
+    if local_dns::is_installed(&local_config::managed_domains(
+        LocalState::load().ok().as_ref(),
+        config_arg,
+    )) {
+        local_dns::uninstall(config_arg).await?;
     }
 
     let exe_path = linkup_exe_path()?;

--- a/linkup-cli/src/local_config.rs
+++ b/linkup-cli/src/local_config.rs
@@ -365,7 +365,6 @@ impl From<&LocalState> for ServerConfig {
     }
 }
 
-#[cfg(target_os = "macos")]
 pub fn managed_domains(state: Option<&LocalState>, cfg_path: &Option<String>) -> Vec<String> {
     let config_domains = match config_path(cfg_path).ok() {
         Some(cfg_path) => match get_config(&cfg_path) {
@@ -396,7 +395,6 @@ pub fn managed_domains(state: Option<&LocalState>, cfg_path: &Option<String>) ->
     domain_set.into_iter().collect()
 }
 
-#[cfg(target_os = "macos")]
 pub fn top_level_domains(domains: &[String]) -> Vec<String> {
     domains
         .iter()

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -96,7 +96,6 @@ fn current_version() -> Version {
         .expect("current version on CARGO_PKG_VERSION should be a valid version")
 }
 
-#[cfg(target_os = "macos")]
 fn is_sudo() -> bool {
     let sudo_check = std::process::Command::new("sudo")
         .arg("-n")
@@ -112,7 +111,6 @@ fn is_sudo() -> bool {
     false
 }
 
-#[cfg(target_os = "macos")]
 fn sudo_su() -> Result<()> {
     let status = std::process::Command::new("sudo")
         .arg("su")

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -226,7 +226,6 @@ enum Commands {
     #[clap(about = "View linkup component and service status")]
     Status(commands::StatusArgs),
 
-    #[cfg(target_os = "macos")]
     #[clap(about = "Speed up your local environment by routing traffic locally when possible")]
     LocalDNS(commands::LocalDnsArgs),
 
@@ -272,7 +271,6 @@ async fn main() -> anyhow::Result<()> {
         Commands::Local(args) => commands::local(args).await,
         Commands::Remote(args) => commands::remote(args).await,
         Commands::Status(args) => commands::status(args),
-        #[cfg(target_os = "macos")]
         Commands::LocalDNS(args) => commands::local_dns(args, &cli.config).await,
         Commands::Completion(args) => commands::completion(args),
         Commands::Preview(args) => commands::preview(args, &cli.config).await,

--- a/linkup-cli/src/services/mod.rs
+++ b/linkup-cli/src/services/mod.rs
@@ -4,11 +4,9 @@ use sysinfo::{ProcessRefreshKind, RefreshKind, System};
 use thiserror::Error;
 
 mod cloudflare_tunnel;
-#[cfg(target_os = "macos")]
 mod local_dns_server;
 mod local_server;
 
-#[cfg(target_os = "macos")]
 pub use local_dns_server::LocalDnsServer;
 pub use local_server::LocalServer;
 pub use sysinfo::{Pid, Signal};

--- a/local-server/src/certificates/mod.rs
+++ b/local-server/src/certificates/mod.rs
@@ -92,7 +92,12 @@ pub fn setup_self_signed_certificates(
             println!(
             "For self-signed certificates to work with Firefox, you need to have nss installed."
         );
-            println!("You can find it on https://formulae.brew.sh/formula/nss.");
+            let nss_url = if cfg!(target_os = "macos") {
+                "https://formulae.brew.sh/formula/nss"
+            } else {
+                "sudo apt install libnss3-tools"
+            };
+            println!("You can install it with {}.", nss_url);
             println!("Please install it and then try to install local-dns again.");
 
             return Err(SetupError::MissingNSS);

--- a/local-server/src/certificates/mod.rs
+++ b/local-server/src/certificates/mod.rs
@@ -301,14 +301,14 @@ fn remove_ca_from_keychain() -> Result<(), UninstallError> {
         .stdout(process::Stdio::null())
         .stderr(process::Stdio::null())
         .status()
-        .map_err(|error| UninstallError::UpdateCaCertificates(error.to_string()))?
+        .map_err(|error| UninstallError::DeleteCaCertificate(error.to_string()))?
         .success()
         .then_some(())
         .ok_or_else(|| {
-            UninstallError::UpdateCaCertificates(
+            UninstallError::DeleteCaCertificate(
                 "update-ca-certificates command returned unsuccessful exit status".to_string(),
             )
-        })?;
+        })
 }
 
 fn firefox_profiles_cert_storages() -> Vec<String> {

--- a/local-server/src/certificates/mod.rs
+++ b/local-server/src/certificates/mod.rs
@@ -304,9 +304,11 @@ fn remove_ca_from_keychain() -> Result<(), UninstallError> {
         .map_err(|error| UninstallError::UpdateCaCertificates(error.to_string()))?
         .success()
         .then_some(())
-        .ok_or_else(|| UninstallError::UpdateCaCertificates(
-            "update-ca-certificates command returned unsuccessful exit status".to_string(),
-        ))?;
+        .ok_or_else(|| {
+            UninstallError::UpdateCaCertificates(
+                "update-ca-certificates command returned unsuccessful exit status".to_string(),
+            )
+        })?;
 }
 
 fn firefox_profiles_cert_storages() -> Vec<String> {

--- a/local-server/src/certificates/mod.rs
+++ b/local-server/src/certificates/mod.rs
@@ -93,7 +93,7 @@ pub fn setup_self_signed_certificates(
             "For self-signed certificates to work with Firefox, you need to have nss installed."
         );
             let nss_url = if cfg!(target_os = "macos") {
-                "https://formulae.brew.sh/formula/nss"
+                "`brew install nss`"
             } else {
                 "`sudo apt install libnss3-tools`"
             };
@@ -119,7 +119,7 @@ pub enum UninstallError {
     RemoveCertsFolder(String),
     #[error("Failed to remove CA certificate from keychain: {0}")]
     DeleteCaCertificate(String),
-    #[error("Failed to update CA certificate registry from keychain: {0}")]
+    #[error("Failed to refresh CA certificate registry: {0}")]
     RefreshCaCertificateRegistry(String),
 }
 

--- a/local-server/src/certificates/mod.rs
+++ b/local-server/src/certificates/mod.rs
@@ -119,6 +119,8 @@ pub enum UninstallError {
     RemoveCertsFolder(String),
     #[error("Failed to remove CA certificate from keychain: {0}")]
     DeleteCaCertificate(String),
+    #[error("Failed to update CA certificate registry from keychain: {0}")]
+    RefreshCaCertificateRegistry(String),
 }
 
 pub fn uninstall_self_signed_certificates(certs_dir: &Path) -> Result<(), UninstallError> {
@@ -301,11 +303,11 @@ fn remove_ca_from_keychain() -> Result<(), UninstallError> {
         .stdout(process::Stdio::null())
         .stderr(process::Stdio::null())
         .status()
-        .map_err(|error| UninstallError::DeleteCaCertificate(error.to_string()))?
+        .map_err(|error| UninstallError::RefreshCaCertificateRegistry(error.to_string()))?
         .success()
         .then_some(())
         .ok_or_else(|| {
-            UninstallError::DeleteCaCertificate(
+            UninstallError::RefreshCaCertificateRegistry(
                 "update-ca-certificates command returned unsuccessful exit status".to_string(),
             )
         })

--- a/local-server/src/certificates/mod.rs
+++ b/local-server/src/certificates/mod.rs
@@ -301,9 +301,12 @@ fn remove_ca_from_keychain() -> Result<(), UninstallError> {
         .stdout(process::Stdio::null())
         .stderr(process::Stdio::null())
         .status()
-        .expect("Failed to update CA certificates");
-
-    Ok(())
+        .map_err(|error| UninstallError::UpdateCaCertificates(error.to_string()))?
+        .success()
+        .then_some(())
+        .ok_or_else(|| UninstallError::UpdateCaCertificates(
+            "update-ca-certificates command returned unsuccessful exit status".to_string(),
+        ))?;
 }
 
 fn firefox_profiles_cert_storages() -> Vec<String> {

--- a/local-server/src/certificates/mod.rs
+++ b/local-server/src/certificates/mod.rs
@@ -95,7 +95,7 @@ pub fn setup_self_signed_certificates(
             let nss_url = if cfg!(target_os = "macos") {
                 "https://formulae.brew.sh/formula/nss"
             } else {
-                "sudo apt install libnss3-tools"
+                "`sudo apt install libnss3-tools`"
             };
             println!("You can install it with {}.", nss_url);
             println!("Please install it and then try to install local-dns again.");


### PR DESCRIPTION
There's no such cli tool like `security` on Ubuntu, so everything is mostly manual.

**Where do certs live in Linux**
Certs live in `/etc/ssl/certs`, but this directory is mostly a collection of symlinks that shouldn't be updated directly.
Instead, we copy our cert to `/usr/local/share/ca-certificates` and then run `update-ca-certificates` to update the symlinks.  

**Where do Firefox certs live in Linux**
Depends!
I found three places depending on how Firefox was installed and what your Linux is.
```
    let profile_dirs = [
        ".mozilla/firefox",
        "snap/firefox/common/.mozilla/firefox",
        ".var/app/org.mozilla.firefox/.mozilla/firefox",
    ];
```

**How to test**
- pull the branch on a Ubuntu machine
- `cd linkup-cli && cargo install --path .`
- `cd ..` — get back to the root of the repo
- `sudo setcap cap_net_bind_service=+ep ~/.cargo/bin/linkup`
- `export LINKUP_CONFIG=~/linkup/linkup-config.yaml`
- `export PATH=$PATH:~/.cargo/bin/linkup >> ~/.bashrc`
- `source ~/.bashrc`
- `linkup start`
- `linkup local-dns install`
- `linkup health`


**Resourses:**
- https://documentation.ubuntu.com/server/how-to/security/install-a-root-ca-certificate-in-the-trust-store/index.html
- https://superuser.com/questions/437330/how-do-you-add-a-certificate-authority-ca-to-ubuntu