### PR TITLE
refactor: restructure websocket implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,6 +1777,7 @@ dependencies = [
  "rustls-pemfile",
  "thiserror 2.0.11",
  "tokio",
+ "tokio-tungstenite",
  "tower 0.5.2",
  "tower-http",
 ]

--- a/local-server/Cargo.toml
+++ b/local-server/Cargo.toml
@@ -28,7 +28,7 @@ tokio = { version = "1.43.0", features = [
     "signal",
     "rt-multi-thread",
 ] }
-tokio-tungstenite = "*"
+tokio-tungstenite = "0.26.1"
 tower-http = { version = "0.6.2", features = ["trace"] }
 tower = "0.5.2"
 rcgen = { version = "0.13", features = ["x509-parser"] }

--- a/local-server/Cargo.toml
+++ b/local-server/Cargo.toml
@@ -8,7 +8,7 @@ name = "linkup_local_server"
 path = "src/lib.rs"
 
 [dependencies]
-axum = { version = "0.8.1", features = ["http2", "json"] }
+axum = { version = "0.8.1", features = ["http2", "json", "ws"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 http = "1.2.0"
 hickory-server = { version = "0.25.1", features = ["resolver"] }

--- a/local-server/Cargo.toml
+++ b/local-server/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1.43.0", features = [
     "signal",
     "rt-multi-thread",
 ] }
+tokio-tungstenite = "*"
 tower-http = { version = "0.6.2", features = ["trace"] }
 tower = "0.5.2"
 rcgen = { version = "0.13", features = ["x509-parser"] }

--- a/local-server/src/lib.rs
+++ b/local-server/src/lib.rs
@@ -228,7 +228,7 @@ async fn linkup_request_handler(
     let extra_headers = get_additional_headers(&url, &headers, &session_name, &target_service);
 
     match ws.0 {
-        Some(upstream_upgrade) => {
+        Some(downstream_upgrade) => {
             let mut url = target_service.url;
             if url.starts_with("http://") {
                 url = url.replace("http://", "ws://");
@@ -264,7 +264,7 @@ async fn linkup_request_handler(
                 };
 
             let mut upstream_upgrade_response =
-                upstream_upgrade.on_upgrade(ws::context_handle_socket(upstream_ws_stream));
+                downstream_upgrade.on_upgrade(ws::context_handle_socket(upstream_ws_stream));
 
             let websocket_upgrade_response_headers = upstream_upgrade_response.headers_mut();
             for upstream_header in upstream_response.headers() {

--- a/local-server/src/lib.rs
+++ b/local-server/src/lib.rs
@@ -1,9 +1,6 @@
 use axum::{
     body::Body,
-    extract::{
-        ws::{WebSocket, WebSocketUpgrade},
-        DefaultBodyLimit, FromRequestParts, Json, Request,
-    },
+    extract::{DefaultBodyLimit, Json, Request},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{any, get, post},
@@ -26,11 +23,11 @@ use hickory_server::{
     },
     ServerFuture,
 };
-use http::{header::HeaderMap, request::Parts, Uri};
+use http::{header::HeaderMap, Uri};
 use hyper_rustls::HttpsConnector;
 use hyper_util::{
     client::legacy::{connect::HttpConnector, Client},
-    rt::{TokioExecutor, TokioIo},
+    rt::TokioExecutor,
 };
 use linkup::{
     allow_all_cors, get_additional_headers, get_target_service, MemoryStringStore, NameKind,
@@ -38,9 +35,7 @@ use linkup::{
 };
 use rustls::ServerConfig;
 use std::{
-    future::Future,
     net::{Ipv4Addr, SocketAddr},
-    pin::Pin,
     str::FromStr,
 };
 use std::{path::Path, sync::Arc};
@@ -49,6 +44,7 @@ use tower::ServiceBuilder;
 use tower_http::trace::{DefaultOnRequest, DefaultOnResponse, TraceLayer};
 
 pub mod certificates;
+mod ws;
 
 type HttpsClient = Client<HttpsConnector<HttpConnector>, Body>;
 
@@ -184,31 +180,10 @@ pub async fn start_dns_server(linkup_session_name: String, domains: Vec<String>)
     server.block_until_done().await.unwrap();
 }
 
-struct ExtractOptionalWebSocketUpgrade(Option<WebSocketUpgrade>);
-
-impl<S> FromRequestParts<S> for ExtractOptionalWebSocketUpgrade
-where
-    S: Send + Sync,
-{
-    type Rejection = (StatusCode, &'static str);
-
-    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let upgrade = WebSocketUpgrade::from_request_parts(parts, state).await;
-
-        match upgrade {
-            Ok(upgrade) => Ok(ExtractOptionalWebSocketUpgrade(Some(upgrade))),
-            Err(_) => {
-                // TODO: Maybe log?
-                Ok(ExtractOptionalWebSocketUpgrade(None))
-            }
-        }
-    }
-}
-
 async fn linkup_request_handler(
     Extension(store): Extension<MemoryStringStore>,
     Extension(client): Extension<HttpsClient>,
-    ws: ExtractOptionalWebSocketUpgrade,
+    ws: ws::ExtractOptionalWebSocketUpgrade,
     req: Request,
 ) -> Response {
     let sessions = SessionAllocator::new(&store);
@@ -253,7 +228,7 @@ async fn linkup_request_handler(
 
     match ws.0 {
         Some(upgrade) => {
-            let mut res = upgrade.on_upgrade(context_handle_socket(extra_headers));
+            let mut res = upgrade.on_upgrade(ws::context_handle_socket(extra_headers));
 
             res.headers_mut().extend(allow_all_cors());
 
@@ -261,31 +236,6 @@ async fn linkup_request_handler(
         }
         None => handle_http_req(req, target_service, extra_headers, client).await,
     }
-}
-
-fn context_handle_socket(
-    header_map: linkup::HeaderMap,
-) -> Box<dyn FnOnce(WebSocket) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send> {
-    let header_map = Arc::new(header_map);
-
-    Box::new(move |mut socket: WebSocket| {
-        let header_map = Arc::clone(&header_map);
-
-        Box::pin(async move {
-            println!("Got headers: {:?}", header_map);
-
-            while let Some(msg_result) = socket.recv().await {
-                let msg = match msg_result {
-                    Ok(msg) => msg,
-                    Err(_) => return,
-                };
-
-                if socket.send(msg).await.is_err() {
-                    return;
-                }
-            }
-        })
-    })
 }
 
 async fn handle_http_req(
@@ -322,119 +272,6 @@ async fn handle_http_req(
     resp.headers_mut().extend(allow_all_cors());
 
     resp.into_response()
-}
-
-async fn handle_ws_req(
-    req: Request,
-    target_service: TargetService,
-    extra_headers: linkup::HeaderMap,
-    client: HttpsClient,
-) -> Response {
-    let extra_http_headers: HeaderMap = extra_headers.into();
-
-    let target_ws_req_result = Request::builder()
-        .uri(target_service.url)
-        .method(req.method().clone())
-        .body(Body::empty());
-
-    let mut target_ws_req = match target_ws_req_result {
-        Ok(request) => request,
-        Err(e) => {
-            return ApiError::new(
-                format!("Failed to build request: {}", e),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            )
-            .into_response();
-        }
-    };
-
-    target_ws_req.headers_mut().extend(req.headers().clone());
-    target_ws_req.headers_mut().extend(extra_http_headers);
-    target_ws_req.headers_mut().remove(http::header::HOST);
-
-    // Send the modified request to the target service.
-    let target_ws_resp = match client.request(target_ws_req).await {
-        Ok(resp) => resp,
-        Err(e) => {
-            return ApiError::new(
-                format!("Failed to proxy request: {}", e),
-                StatusCode::BAD_GATEWAY,
-            )
-            .into_response()
-        }
-    };
-
-    let status = target_ws_resp.status();
-    if status != 101 {
-        return ApiError::new(
-            format!(
-                "Failed to proxy request: expected 101 Switching Protocols, got {}",
-                status
-            ),
-            StatusCode::BAD_GATEWAY,
-        )
-        .into_response();
-    }
-
-    let target_ws_resp_headers = target_ws_resp.headers().clone();
-
-    let upgraded_target = match hyper::upgrade::on(target_ws_resp).await {
-        Ok(upgraded) => upgraded,
-        Err(e) => {
-            return ApiError::new(
-                format!("Failed to upgrade connection: {}", e),
-                StatusCode::BAD_GATEWAY,
-            )
-            .into_response()
-        }
-    };
-
-    tokio::spawn(async move {
-        // We won't get passed this until the 101 response returns to the client
-        let upgraded_incoming = match hyper::upgrade::on(req).await {
-            Ok(upgraded) => upgraded,
-            Err(e) => {
-                println!("Failed to upgrade incoming connection: {}", e);
-                return;
-            }
-        };
-
-        let mut incoming_stream = TokioIo::new(upgraded_incoming);
-        let mut target_stream = TokioIo::new(upgraded_target);
-
-        let res = tokio::io::copy_bidirectional(&mut incoming_stream, &mut target_stream).await;
-
-        match res {
-            Ok((incoming_to_target, target_to_incoming)) => {
-                println!(
-                    "Copied {} bytes from incoming to target and {} bytes from target to incoming",
-                    incoming_to_target, target_to_incoming
-                );
-            }
-            Err(e) => {
-                eprintln!("Error copying between incoming and target: {}", e);
-            }
-        }
-    });
-
-    let mut resp_builder = Response::builder().status(101);
-    let resp_headers_result = resp_builder.headers_mut();
-    if let Some(resp_headers) = resp_headers_result {
-        for (header, value) in target_ws_resp_headers {
-            if let Some(header_name) = header {
-                resp_headers.append(header_name, value);
-            }
-        }
-    }
-
-    match resp_builder.body(Body::empty()) {
-        Ok(response) => response,
-        Err(e) => ApiError::new(
-            format!("Failed to build response: {}", e),
-            StatusCode::INTERNAL_SERVER_ERROR,
-        )
-        .into_response(),
-    }
 }
 
 async fn linkup_config_handler(

--- a/local-server/src/ws.rs
+++ b/local-server/src/ws.rs
@@ -3,7 +3,7 @@ use std::{future::Future, pin::Pin};
 use axum::extract::{ws::WebSocket, FromRequestParts, WebSocketUpgrade};
 use futures::{SinkExt, StreamExt};
 use http::{request::Parts, StatusCode};
-use tokio::{net::TcpStream, select};
+use tokio::net::TcpStream;
 use tokio_tungstenite::{
     tungstenite::{self, Message},
     MaybeTlsStream, WebSocketStream,
@@ -30,7 +30,7 @@ where
     }
 }
 
-pub fn tungstenite_to_axum(message: tungstenite::Message) -> axum::extract::ws::Message {
+fn tungstenite_to_axum(message: tungstenite::Message) -> axum::extract::ws::Message {
     match message {
         Message::Text(utf8_bytes) => axum::extract::ws::Message::Text(
             axum::extract::ws::Utf8Bytes::from(utf8_bytes.as_str()),
@@ -49,7 +49,7 @@ pub fn tungstenite_to_axum(message: tungstenite::Message) -> axum::extract::ws::
     }
 }
 
-pub fn axum_to_tungstenite(message: axum::extract::ws::Message) -> tungstenite::Message {
+fn axum_to_tungstenite(message: axum::extract::ws::Message) -> tungstenite::Message {
     match message {
         axum::extract::ws::Message::Text(utf8_bytes) => {
             tungstenite::Message::Text(tungstenite::Utf8Bytes::from(utf8_bytes.as_str()))
@@ -76,70 +76,77 @@ pub fn context_handle_socket(
 ) -> WrappedSocketHandler {
     Box::new(move |downstream: WebSocket| {
         Box::pin(async move {
+            use futures::future::{select, Either};
+
             let (mut upstream_write, mut upstream_read) = upstream_ws.split();
             let (mut downstream_write, mut downstream_read) = downstream.split();
 
             let mut is_closed = false;
 
             loop {
-                select! {
-                    Some(message) = upstream_read.next() => {
-                        match message {
-                            Ok(message) => {
-                                let axum_message = tungstenite_to_axum(message);
+                match select(downstream_read.next(), upstream_read.next()).await {
+                    Either::Left((Some(downstream_message), _)) => match downstream_message {
+                        Ok(message) => {
+                            let tungstenite_message = axum_to_tungstenite(message);
 
-                                match &axum_message {
-                                    axum::extract::ws::Message::Close(_) => {
-                                        let _ = downstream_write.send(axum_message).await;
+                            match &tungstenite_message {
+                                Message::Close(_) => {
+                                    let _ = upstream_write.send(tungstenite_message).await;
 
-                                        if is_closed {
-                                            break;
-                                        } else {
-                                            is_closed = true;
-                                        }
-                                    },
-                                    _ => {
-                                        if let Err(e) = downstream_write.send(axum_message).await {
-                                            eprintln!("Error sending message to upstream: {}", e);
-                                            break;
-                                        }
+                                    if is_closed {
+                                        break;
+                                    } else {
+                                        is_closed = true;
                                     }
                                 }
-                            },
-                            Err(e) => {
-                                eprint!("Got error on reading message from upstream: {}", e);
-                                break;
-                            },
-                        }
-                    }
-                    Some(message) = downstream_read.next() => {
-                        match message {
-                            Ok(message) => {
-                                let tungstenite_message = axum_to_tungstenite(message);
-
-                                match &tungstenite_message {
-                                    Message::Close(_) => {
-                                        let _ = upstream_write.send(tungstenite_message).await;
-
-                                        if is_closed {
-                                            break;
-                                        } else {
-                                            is_closed = true;
-                                        }
-                                    },
-                                    _ => {
-                                        if let Err(e) = upstream_write.send(tungstenite_message).await {
-                                            eprintln!("Error sending message to upstream: {}", e);
-                                            break;
-                                        }
+                                _ => {
+                                    if let Err(e) = upstream_write.send(tungstenite_message).await {
+                                        eprintln!("Error sending message to upstream: {}", e);
+                                        break;
                                     }
                                 }
-                            },
-                            Err(e) => {
-                                eprint!("Got error on reading message from downstream: {}", e);
-                                break;
-                            },
+                            }
                         }
+                        Err(e) => {
+                            eprint!("Got error on reading message from downstream: {}", e);
+                            break;
+                        }
+                    },
+                    Either::Right((Some(upstream_message), _)) => match upstream_message {
+                        Ok(message) => {
+                            let axum_message = tungstenite_to_axum(message);
+
+                            match &axum_message {
+                                axum::extract::ws::Message::Close(_) => {
+                                    let _ = downstream_write.send(axum_message).await;
+
+                                    if is_closed {
+                                        break;
+                                    } else {
+                                        is_closed = true;
+                                    }
+                                }
+                                _ => {
+                                    if let Err(e) = downstream_write.send(axum_message).await {
+                                        eprintln!("Error sending message to upstream: {}", e);
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            eprint!("Got error on reading message from upstream: {}", e);
+                            break;
+                        }
+                    },
+                    other => {
+                        // TODO: On the select! macro, if nothing is matched, it panics. I guess
+                        // this might be better than panicking? Or do we want to "fail loudly" here?
+                        //
+                        // https://docs.rs/tokio/latest/tokio/macro.select.html#panics
+                        eprint!("Received unexpected message: {other:?}");
+
+                        break;
                     }
                 }
             }
@@ -149,118 +156,3 @@ pub fn context_handle_socket(
         })
     })
 }
-
-// // Old websocket handler
-//
-// async fn handle_ws_req(
-//     req: Request,
-//     target_service: TargetService,
-//     extra_headers: linkup::HeaderMap,
-//     client: HttpsClient,
-// ) -> Response {
-//     let extra_http_headers: HeaderMap = extra_headers.into();
-
-//     let target_ws_req_result = Request::builder()
-//         .uri(target_service.url)
-//         .method(req.method().clone())
-//         .body(Body::empty());
-
-//     let mut target_ws_req = match target_ws_req_result {
-//         Ok(request) => request,
-//         Err(e) => {
-//             return ApiError::new(
-//                 format!("Failed to build request: {}", e),
-//                 StatusCode::INTERNAL_SERVER_ERROR,
-//             )
-//             .into_response();
-//         }
-//     };
-
-//     target_ws_req.headers_mut().extend(req.headers().clone());
-//     target_ws_req.headers_mut().extend(extra_http_headers);
-//     target_ws_req.headers_mut().remove(http::header::HOST);
-
-//     // Send the modified request to the target service.
-//     let target_ws_resp = match client.request(target_ws_req).await {
-//         Ok(resp) => resp,
-//         Err(e) => {
-//             return ApiError::new(
-//                 format!("Failed to proxy request: {}", e),
-//                 StatusCode::BAD_GATEWAY,
-//             )
-//             .into_response()
-//         }
-//     };
-
-//     let status = target_ws_resp.status();
-//     if status != 101 {
-//         return ApiError::new(
-//             format!(
-//                 "Failed to proxy request: expected 101 Switching Protocols, got {}",
-//                 status
-//             ),
-//             StatusCode::BAD_GATEWAY,
-//         )
-//         .into_response();
-//     }
-
-//     let target_ws_resp_headers = target_ws_resp.headers().clone();
-
-//     let upgraded_target = match hyper::upgrade::on(target_ws_resp).await {
-//         Ok(upgraded) => upgraded,
-//         Err(e) => {
-//             return ApiError::new(
-//                 format!("Failed to upgrade connection: {}", e),
-//                 StatusCode::BAD_GATEWAY,
-//             )
-//             .into_response()
-//         }
-//     };
-
-//     tokio::spawn(async move {
-//         // We won't get passed this until the 101 response returns to the client
-//         let upgraded_incoming = match hyper::upgrade::on(req).await {
-//             Ok(upgraded) => upgraded,
-//             Err(e) => {
-//                 println!("Failed to upgrade incoming connection: {}", e);
-//                 return;
-//             }
-//         };
-
-//         let mut incoming_stream = TokioIo::new(upgraded_incoming);
-//         let mut target_stream = TokioIo::new(upgraded_target);
-
-//         let res = tokio::io::copy_bidirectional(&mut incoming_stream, &mut target_stream).await;
-
-//         match res {
-//             Ok((incoming_to_target, target_to_incoming)) => {
-//                 println!(
-//                     "Copied {} bytes from incoming to target and {} bytes from target to incoming",
-//                     incoming_to_target, target_to_incoming
-//                 );
-//             }
-//             Err(e) => {
-//                 eprintln!("Error copying between incoming and target: {}", e);
-//             }
-//         }
-//     });
-
-//     let mut resp_builder = Response::builder().status(101);
-//     let resp_headers_result = resp_builder.headers_mut();
-//     if let Some(resp_headers) = resp_headers_result {
-//         for (header, value) in target_ws_resp_headers {
-//             if let Some(header_name) = header {
-//                 resp_headers.append(header_name, value);
-//             }
-//         }
-//     }
-
-//     match resp_builder.body(Body::empty()) {
-//         Ok(response) => response,
-//         Err(e) => ApiError::new(
-//             format!("Failed to build response: {}", e),
-//             StatusCode::INTERNAL_SERVER_ERROR,
-//         )
-//         .into_response(),
-//     }
-// }

--- a/local-server/src/ws.rs
+++ b/local-server/src/ws.rs
@@ -1,9 +1,13 @@
 use std::{future::Future, pin::Pin};
 
 use axum::extract::{ws::WebSocket, FromRequestParts, WebSocketUpgrade};
+use futures::{SinkExt, StreamExt};
 use http::{request::Parts, StatusCode};
-use tokio::net::TcpStream;
-use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+use tokio::{net::TcpStream, select};
+use tokio_tungstenite::{
+    tungstenite::{self, Message},
+    MaybeTlsStream, WebSocketStream,
+};
 
 pub struct ExtractOptionalWebSocketUpgrade(pub Option<WebSocketUpgrade>);
 
@@ -26,21 +30,119 @@ where
     }
 }
 
-pub fn context_handle_socket(
-    _upstream_ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
-) -> Box<dyn FnOnce(WebSocket) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send> {
-    Box::new(move |mut socket: WebSocket| {
-        Box::pin(async move {
-            while let Some(msg_result) = socket.recv().await {
-                let msg = match msg_result {
-                    Ok(msg) => msg,
-                    Err(_) => return,
-                };
+pub fn tungstenite_to_axum(message: tungstenite::Message) -> axum::extract::ws::Message {
+    match message {
+        Message::Text(utf8_bytes) => axum::extract::ws::Message::Text(
+            axum::extract::ws::Utf8Bytes::from(utf8_bytes.as_str()),
+        ),
+        Message::Binary(bytes) => axum::extract::ws::Message::Binary(bytes),
+        Message::Ping(bytes) => axum::extract::ws::Message::Ping(bytes),
+        Message::Pong(bytes) => axum::extract::ws::Message::Pong(bytes),
+        Message::Close(close_frame) => match close_frame {
+            Some(frame) => axum::extract::ws::Message::Close(Some(axum::extract::ws::CloseFrame {
+                code: frame.code.into(),
+                reason: axum::extract::ws::Utf8Bytes::from(frame.reason.as_str()),
+            })),
+            None => axum::extract::ws::Message::Close(None),
+        },
+        Message::Frame(_frame) => unreachable!(),
+    }
+}
 
-                if socket.send(msg).await.is_err() {
-                    return;
+pub fn axum_to_tungstenite(message: axum::extract::ws::Message) -> tungstenite::Message {
+    match message {
+        axum::extract::ws::Message::Text(utf8_bytes) => {
+            tungstenite::Message::Text(tungstenite::Utf8Bytes::from(utf8_bytes.as_str()))
+        }
+        axum::extract::ws::Message::Binary(bytes) => tungstenite::Message::Binary(bytes),
+        axum::extract::ws::Message::Ping(bytes) => tungstenite::Message::Ping(bytes),
+        axum::extract::ws::Message::Pong(bytes) => tungstenite::Message::Pong(bytes),
+        axum::extract::ws::Message::Close(close_frame) => {
+            tungstenite::Message::Close(close_frame.map(|frame| {
+                tungstenite::protocol::frame::CloseFrame {
+                    code: frame.code.into(),
+                    reason: tungstenite::Utf8Bytes::from(frame.reason.as_str()),
+                }
+            }))
+        }
+    }
+}
+
+pub fn context_handle_socket(
+    upstream_ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
+) -> Box<dyn FnOnce(WebSocket) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send> {
+    Box::new(move |downstream: WebSocket| {
+        Box::pin(async move {
+            let (mut upstream_write, mut upstream_read) = upstream_ws.split();
+            let (mut downstream_write, mut downstream_read) = downstream.split();
+
+            let mut is_closed = false;
+
+            loop {
+                select! {
+                    Some(message) = upstream_read.next() => {
+                        match message {
+                            Ok(message) => {
+                                let axum_message = tungstenite_to_axum(message);
+
+                                match &axum_message {
+                                    axum::extract::ws::Message::Close(_) => {
+                                        let _ = downstream_write.send(axum_message).await;
+
+                                        if is_closed {
+                                            break;
+                                        } else {
+                                            is_closed = true;
+                                        }
+                                    },
+                                    _ => {
+                                        if let Err(e) = downstream_write.send(axum_message).await {
+                                            eprintln!("Error sending message to upstream: {}", e);
+                                            break;
+                                        }
+                                    }
+                                }
+                            },
+                            Err(e) => {
+                                eprint!("Got error on reading message from upstream: {}", e);
+                                break;
+                            },
+                        }
+                    }
+                    Some(message) = downstream_read.next() => {
+                        match message {
+                            Ok(message) => {
+                                let tungstenite_message = axum_to_tungstenite(message);
+
+                                match &tungstenite_message {
+                                    Message::Close(_) => {
+                                        let _ = upstream_write.send(tungstenite_message).await;
+
+                                        if is_closed {
+                                            break;
+                                        } else {
+                                            is_closed = true;
+                                        }
+                                    },
+                                    _ => {
+                                        if let Err(e) = upstream_write.send(tungstenite_message).await {
+                                            eprintln!("Error sending message to upstream: {}", e);
+                                            break;
+                                        }
+                                    }
+                                }
+                            },
+                            Err(e) => {
+                                eprint!("Got error on reading message from downstream: {}", e);
+                                break;
+                            },
+                        }
+                    }
                 }
             }
+
+            let _ = upstream_write.close().await;
+            let _ = downstream_write.close().await;
         })
     })
 }

--- a/local-server/src/ws.rs
+++ b/local-server/src/ws.rs
@@ -1,0 +1,165 @@
+use std::{future::Future, pin::Pin, sync::Arc};
+
+use axum::extract::{ws::WebSocket, FromRequestParts, WebSocketUpgrade};
+use http::{request::Parts, StatusCode};
+
+pub struct ExtractOptionalWebSocketUpgrade(pub Option<WebSocketUpgrade>);
+
+impl<S> FromRequestParts<S> for ExtractOptionalWebSocketUpgrade
+where
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, &'static str);
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let upgrade = WebSocketUpgrade::from_request_parts(parts, state).await;
+
+        match upgrade {
+            Ok(upgrade) => Ok(ExtractOptionalWebSocketUpgrade(Some(upgrade))),
+            Err(_) => {
+                // TODO: Maybe log?
+                Ok(ExtractOptionalWebSocketUpgrade(None))
+            }
+        }
+    }
+}
+
+pub fn context_handle_socket(
+    header_map: linkup::HeaderMap,
+) -> Box<dyn FnOnce(WebSocket) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send> {
+    let header_map = Arc::new(header_map);
+
+    Box::new(move |mut socket: WebSocket| {
+        let header_map = Arc::clone(&header_map);
+
+        Box::pin(async move {
+            println!("Got headers: {:?}", header_map);
+
+            while let Some(msg_result) = socket.recv().await {
+                let msg = match msg_result {
+                    Ok(msg) => msg,
+                    Err(_) => return,
+                };
+
+                if socket.send(msg).await.is_err() {
+                    return;
+                }
+            }
+        })
+    })
+}
+
+// // Old websocket handler
+//
+// async fn handle_ws_req(
+//     req: Request,
+//     target_service: TargetService,
+//     extra_headers: linkup::HeaderMap,
+//     client: HttpsClient,
+// ) -> Response {
+//     let extra_http_headers: HeaderMap = extra_headers.into();
+
+//     let target_ws_req_result = Request::builder()
+//         .uri(target_service.url)
+//         .method(req.method().clone())
+//         .body(Body::empty());
+
+//     let mut target_ws_req = match target_ws_req_result {
+//         Ok(request) => request,
+//         Err(e) => {
+//             return ApiError::new(
+//                 format!("Failed to build request: {}", e),
+//                 StatusCode::INTERNAL_SERVER_ERROR,
+//             )
+//             .into_response();
+//         }
+//     };
+
+//     target_ws_req.headers_mut().extend(req.headers().clone());
+//     target_ws_req.headers_mut().extend(extra_http_headers);
+//     target_ws_req.headers_mut().remove(http::header::HOST);
+
+//     // Send the modified request to the target service.
+//     let target_ws_resp = match client.request(target_ws_req).await {
+//         Ok(resp) => resp,
+//         Err(e) => {
+//             return ApiError::new(
+//                 format!("Failed to proxy request: {}", e),
+//                 StatusCode::BAD_GATEWAY,
+//             )
+//             .into_response()
+//         }
+//     };
+
+//     let status = target_ws_resp.status();
+//     if status != 101 {
+//         return ApiError::new(
+//             format!(
+//                 "Failed to proxy request: expected 101 Switching Protocols, got {}",
+//                 status
+//             ),
+//             StatusCode::BAD_GATEWAY,
+//         )
+//         .into_response();
+//     }
+
+//     let target_ws_resp_headers = target_ws_resp.headers().clone();
+
+//     let upgraded_target = match hyper::upgrade::on(target_ws_resp).await {
+//         Ok(upgraded) => upgraded,
+//         Err(e) => {
+//             return ApiError::new(
+//                 format!("Failed to upgrade connection: {}", e),
+//                 StatusCode::BAD_GATEWAY,
+//             )
+//             .into_response()
+//         }
+//     };
+
+//     tokio::spawn(async move {
+//         // We won't get passed this until the 101 response returns to the client
+//         let upgraded_incoming = match hyper::upgrade::on(req).await {
+//             Ok(upgraded) => upgraded,
+//             Err(e) => {
+//                 println!("Failed to upgrade incoming connection: {}", e);
+//                 return;
+//             }
+//         };
+
+//         let mut incoming_stream = TokioIo::new(upgraded_incoming);
+//         let mut target_stream = TokioIo::new(upgraded_target);
+
+//         let res = tokio::io::copy_bidirectional(&mut incoming_stream, &mut target_stream).await;
+
+//         match res {
+//             Ok((incoming_to_target, target_to_incoming)) => {
+//                 println!(
+//                     "Copied {} bytes from incoming to target and {} bytes from target to incoming",
+//                     incoming_to_target, target_to_incoming
+//                 );
+//             }
+//             Err(e) => {
+//                 eprintln!("Error copying between incoming and target: {}", e);
+//             }
+//         }
+//     });
+
+//     let mut resp_builder = Response::builder().status(101);
+//     let resp_headers_result = resp_builder.headers_mut();
+//     if let Some(resp_headers) = resp_headers_result {
+//         for (header, value) in target_ws_resp_headers {
+//             if let Some(header_name) = header {
+//                 resp_headers.append(header_name, value);
+//             }
+//         }
+//     }
+
+//     match resp_builder.body(Body::empty()) {
+//         Ok(response) => response,
+//         Err(e) => ApiError::new(
+//             format!("Failed to build response: {}", e),
+//             StatusCode::INTERNAL_SERVER_ERROR,
+//         )
+//         .into_response(),
+//     }
+// }

--- a/local-server/src/ws.rs
+++ b/local-server/src/ws.rs
@@ -68,9 +68,12 @@ pub fn axum_to_tungstenite(message: axum::extract::ws::Message) -> tungstenite::
     }
 }
 
+type WrappedSocketHandler =
+    Box<dyn FnOnce(WebSocket) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send>;
+
 pub fn context_handle_socket(
     upstream_ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
-) -> Box<dyn FnOnce(WebSocket) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send> {
+) -> WrappedSocketHandler {
     Box::new(move |downstream: WebSocket| {
         Box::pin(async move {
             let (mut upstream_write, mut upstream_read) = upstream_ws.split();

--- a/worker/src/ws.rs
+++ b/worker/src/ws.rs
@@ -1,4 +1,7 @@
+use std::str::FromStr;
+
 use axum::{http::StatusCode, response::IntoResponse};
+use http::{HeaderMap, HeaderName, HeaderValue};
 use linkup::allow_all_cors;
 use worker::{console_log, Error, HttpResponse, WebSocket, WebSocketPair, WebsocketEvent};
 
@@ -9,12 +12,13 @@ use futures::{
 
 use crate::http_error::HttpError;
 
-pub async fn handle_ws_resp(worker_resp: worker::Response) -> impl IntoResponse {
-    let dest_ws_res = match worker_resp.websocket() {
+pub async fn handle_ws_resp(upstream_response: worker::Response) -> impl IntoResponse {
+    let upstream_response_headers = upstream_response.headers().clone();
+    let upstream_ws_result = match upstream_response.websocket() {
         Some(ws) => Ok(ws),
         None => Err(Error::RustError("server did not accept".into())),
     };
-    let dest_ws = match dest_ws_res {
+    let upstream_ws = match upstream_ws_result {
         Ok(ws) => ws,
         Err(e) => {
             return HttpError::new(
@@ -25,7 +29,7 @@ pub async fn handle_ws_resp(worker_resp: worker::Response) -> impl IntoResponse 
         }
     };
 
-    let source_ws = match WebSocketPair::new() {
+    let downstream_ws = match WebSocketPair::new() {
         Ok(ws) => ws,
         Err(e) => {
             return HttpError::new(
@@ -35,38 +39,44 @@ pub async fn handle_ws_resp(worker_resp: worker::Response) -> impl IntoResponse 
             .into_response()
         }
     };
-    let source_ws_server = source_ws.server;
+    let downstream_ws_server = downstream_ws.server;
 
     worker::wasm_bindgen_futures::spawn_local(async move {
-        let mut dest_events = dest_ws.events().expect("could not open dest event stream");
-        let mut source_events = source_ws_server
+        let mut upstream_events = upstream_ws
+            .events()
+            .expect("could not open dest event stream");
+        let mut downstream_events = downstream_ws_server
             .events()
             .expect("could not open source event stream");
 
-        dest_ws.accept().expect("could not accept dest ws");
-        source_ws_server
+        upstream_ws.accept().expect("could not accept dest ws");
+        downstream_ws_server
             .accept()
             .expect("could not accept source ws");
 
+        let mut is_closed = false;
+
         loop {
-            match future::select(source_events.next(), dest_events.next()).await {
-                Either::Left((Some(source_event), _)) => {
+            match future::select(downstream_events.next(), upstream_events.next()).await {
+                Either::Left((Some(downstream_event), _)) => {
                     if let Err(e) = forward_ws_event(
-                        source_event,
-                        &source_ws_server,
-                        &dest_ws,
+                        downstream_event,
+                        &downstream_ws_server,
+                        &upstream_ws,
                         "to destination".into(),
+                        &mut is_closed,
                     ) {
                         console_log!("Error forwarding source event: {:?}", e);
                         break;
                     }
                 }
-                Either::Right((Some(dest_event), _)) => {
+                Either::Right((Some(upstream_event), _)) => {
                     if let Err(e) = forward_ws_event(
-                        dest_event,
-                        &dest_ws,
-                        &source_ws_server,
+                        upstream_event,
+                        &upstream_ws,
+                        &downstream_ws_server,
                         "to source".into(),
+                        &mut is_closed,
                     ) {
                         console_log!("Error forwarding dest event: {:?}", e);
                         break;
@@ -76,8 +86,8 @@ pub async fn handle_ws_resp(worker_resp: worker::Response) -> impl IntoResponse 
                     console_log!("No event received, error");
                     close_with_internal_error(
                         "Received something other than event from streams".to_string(),
-                        &source_ws_server,
-                        &dest_ws,
+                        &downstream_ws_server,
+                        &upstream_ws,
                     );
                     break;
                 }
@@ -85,7 +95,7 @@ pub async fn handle_ws_resp(worker_resp: worker::Response) -> impl IntoResponse 
         }
     });
 
-    let worker_resp = match worker::Response::from_websocket(source_ws.client) {
+    let downstream_resp = match worker::Response::from_websocket(downstream_ws.client) {
         Ok(res) => res,
         Err(e) => {
             return HttpError::new(
@@ -95,7 +105,8 @@ pub async fn handle_ws_resp(worker_resp: worker::Response) -> impl IntoResponse 
             .into_response()
         }
     };
-    let mut resp: HttpResponse = match worker_resp.try_into() {
+
+    let mut resp: HttpResponse = match downstream_resp.try_into() {
         Ok(resp) => resp,
         Err(e) => {
             return HttpError::new(
@@ -105,6 +116,15 @@ pub async fn handle_ws_resp(worker_resp: worker::Response) -> impl IntoResponse 
             .into_response()
         }
     };
+
+    for upstream_header in upstream_response_headers.entries() {
+        if !resp.headers().contains_key(&upstream_header.0) {
+            resp.headers_mut().append(
+                HeaderName::from_str(&upstream_header.0).unwrap(),
+                HeaderValue::from_str(&upstream_header.1).unwrap(),
+            );
+        }
+    }
 
     resp.headers_mut().extend(allow_all_cors());
 
@@ -116,6 +136,7 @@ fn forward_ws_event(
     from: &WebSocket,
     to: &WebSocket,
     description: String,
+    is_closed: &mut bool,
 ) -> Result<(), Error> {
     match event {
         Ok(WebsocketEvent::Message(msg)) => {
@@ -144,11 +165,14 @@ fn forward_ws_event(
             }
         }
         Ok(WebsocketEvent::Close(close)) => {
-            let close_res = to.close(Some(1000), Some(close.reason()));
-            if let Err(e) = close_res {
-                console_log!("Error closing {} with close event: {:?}", description, e);
+            let _ = to.close(Some(1000), Some(close.reason()));
+            if *is_closed {
+                return Err(Error::RustError("Closed!".into()));
+            } else {
+                *is_closed = true;
             }
-            Err(Error::RustError(format!("Close event: {}", close.reason())))
+
+            Ok(())
         }
         Err(e) => {
             let err_msg = format!("Other {} error: {:?}", description, e);

--- a/worker/src/ws.rs
+++ b/worker/src/ws.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use axum::{http::StatusCode, response::IntoResponse};
-use http::{HeaderMap, HeaderName, HeaderValue};
+use http::{HeaderName, HeaderValue};
 use linkup::allow_all_cors;
 use worker::{console_log, Error, HttpResponse, WebSocket, WebSocketPair, WebsocketEvent};
 


### PR DESCRIPTION
Use [tungstenite](https://docs.rs/tungstenite/latest/tungstenite/) for handling websocket on local-server.
With this implementation we should have a more stable handling of the events and specially of the closing.