### PR TITLE
Improve header management on websocket proxying

### DIFF
--- a/linkup-cli/src/services/local_server.rs
+++ b/linkup-cli/src/services/local_server.rs
@@ -59,7 +59,10 @@ impl LocalServer {
         let mut command = process::Command::new(
             env::current_exe().context("Failed to get the current executable")?,
         );
-        command.env("RUST_LOG", "debug");
+        command.env(
+            "RUST_LOG",
+            "info,hickory_server=warn,hyper_util=warn,h2=warn,tower_http=info",
+        );
         command.env("LINKUP_SERVICE_ID", Self::ID);
         command.args([
             "server",

--- a/local-server/src/ws.rs
+++ b/local-server/src/ws.rs
@@ -101,14 +101,14 @@ pub fn context_handle_socket(
                                 }
                                 _ => {
                                     if let Err(e) = upstream_write.send(tungstenite_message).await {
-                                        eprintln!("Error sending message to upstream: {}", e);
+                                        println!("Error sending message to upstream: {}", e);
                                         break;
                                     }
                                 }
                             }
                         }
                         Err(e) => {
-                            eprint!("Got error on reading message from downstream: {}", e);
+                            println!("Got error on reading message from downstream: {}", e);
                             break;
                         }
                     },
@@ -128,14 +128,14 @@ pub fn context_handle_socket(
                                 }
                                 _ => {
                                     if let Err(e) = downstream_write.send(axum_message).await {
-                                        eprintln!("Error sending message to upstream: {}", e);
+                                        println!("Error sending message to upstream: {}", e);
                                         break;
                                     }
                                 }
                             }
                         }
                         Err(e) => {
-                            eprint!("Got error on reading message from upstream: {}", e);
+                            println!("Got error on reading message from upstream: {}", e);
                             break;
                         }
                     },
@@ -144,7 +144,7 @@ pub fn context_handle_socket(
                         // this might be better than panicking? Or do we want to "fail loudly" here?
                         //
                         // https://docs.rs/tokio/latest/tokio/macro.select.html#panics
-                        eprint!("Received unexpected message: {other:?}");
+                        println!("Received unexpected message: {other:?}");
 
                         break;
                     }


### PR DESCRIPTION
- In order for websockets to work well, they must respect websocket headers like `sec-websocket-key`
- One way to do this as a proxy is to "not" and just pass all headers along
- This modifies the local server websocket implementation to pass more headers upstream _and_ downstream, so that more gets through the proxy

There _may_ be problems with the remote worker also after the last websocket refactor - websocket proxying is _hard_. 
Bit unclear though, the implementation there is significantly different.