### PR TITLE
refactor: reimplement download of latest versions

### DIFF
--- a/linkup-cli/src/commands/update.rs
+++ b/linkup-cli/src/commands/update.rs
@@ -1,5 +1,7 @@
-use crate::{commands, current_version, linkup_exe_path, release, InstallationMethod, Result};
+use anyhow::anyhow;
 use std::fs;
+
+use crate::{commands, current_version, linkup_exe_path, release, InstallationMethod, Result};
 
 #[derive(clap::Args)]
 pub struct Args {
@@ -50,7 +52,9 @@ pub async fn update(args: &Args) -> Result<()> {
                 &update.version.channel()
             );
 
-            let new_linkup_path = update.binary.download().await.unwrap();
+            let new_linkup_path = update.binary.download().await.map_err(|error| {
+                anyhow!("Failed to download new version.").context(error.to_string())
+            })?;
 
             let current_linkup_path = linkup_exe_path()?;
             let bkp_linkup_path = current_linkup_path.with_extension("bkp");

--- a/linkup-cli/src/commands/update.rs
+++ b/linkup-cli/src/commands/update.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use anyhow::Context;
 use std::fs;
 
 use crate::{commands, current_version, linkup_exe_path, release, InstallationMethod, Result};
@@ -52,9 +52,11 @@ pub async fn update(args: &Args) -> Result<()> {
                 &update.version.channel()
             );
 
-            let new_linkup_path = update.binary.download().await.map_err(|error| {
-                anyhow!("Failed to download new version.").context(error.to_string())
-            })?;
+            let new_linkup_path = update
+                .binary
+                .download()
+                .await
+                .with_context(|| "Failed to download new version")?;
 
             let current_linkup_path = linkup_exe_path()?;
             let bkp_linkup_path = current_linkup_path.with_extension("bkp");

--- a/linkup-cli/src/release.rs
+++ b/linkup-cli/src/release.rs
@@ -1,67 +1,100 @@
-use std::{
-    env, fs,
-    path::PathBuf,
-    time::{self, Duration},
-};
+mod github {
+    use std::{env, fs, path::PathBuf, time::Duration};
 
-use flate2::read::GzDecoder;
-use linkup::VersionChannel;
-use reqwest::header::HeaderValue;
-use serde::{Deserialize, Serialize};
-use tar::Archive;
-use url::Url;
+    use flate2::read::GzDecoder;
+    use linkup::VersionError;
+    use reqwest::header::HeaderValue;
+    use serde::{de::DeserializeOwned, Deserialize, Serialize};
+    use tar::Archive;
+    use url::Url;
 
-use crate::{linkup_file_path, Version};
-
-const CACHED_LATEST_STABLE_RELEASE_FILE: &str = "latest_release_stable.json";
-const CACHED_LATEST_BETA_RELEASE_FILE: &str = "latest_release_beta.json";
-
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("ReqwestError: {0}")]
-    Reqwest(#[from] reqwest::Error),
-    #[error("IoError: {0}")]
-    Io(#[from] std::io::Error),
-    #[error("File missing from downloaded compressed archive")]
-    MissingBinary,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Asset {
-    name: String,
-    #[serde(rename = "browser_download_url")]
-    download_url: String,
-}
-
-impl Asset {
-    pub async fn download(&self) -> Result<PathBuf, Error> {
-        let response = reqwest::get(&self.download_url).await?;
-
-        let file_path = env::temp_dir().join(&self.name);
-        let mut file = fs::File::create(&file_path)?;
-
-        let mut content = std::io::Cursor::new(response.bytes().await?);
-        std::io::copy(&mut content, &mut file)?;
-
-        Ok(file_path)
+    #[derive(Debug, thiserror::Error)]
+    pub enum Error {
+        #[error("ReqwestError: {0}")]
+        Reqwest(#[from] reqwest::Error),
+        #[error("IoError: {0}")]
+        Io(#[from] std::io::Error),
+        #[error("File missing from downloaded compressed archive")]
+        MissingBinary,
+        #[error("Release have an invalid tag")]
+        InvalidVersionTag(#[from] VersionError),
+        #[error("Hit a rate limit while checking for updates")]
+        RateLimit(u64),
     }
 
-    pub async fn download_decompressed(&self, lookup_name: &str) -> Result<PathBuf, Error> {
-        let file_path = self.download().await?;
-        let file = fs::File::open(&file_path)?;
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Release {
+        #[serde(rename = "name")]
+        pub version: String,
+        pub assets: Vec<Asset>,
+    }
 
-        let decoder = GzDecoder::new(file);
-        let mut archive = Archive::new(decoder);
+    impl Release {
+        /// Examples of Linkup asset files:
+        /// - linkup-1.7.1-x86_64-apple-darwin.tar.gz
+        /// - linkup-1.7.1-aarch64-apple-darwin.tar.gz
+        /// - linkup-1.7.1-x86_64-unknown-linux-gnu.tar.gz
+        /// - linkup-1.7.1-aarch64-unknown-linux-gnu.tar.gz
+        pub fn linkup_asset(&self, os: &str, arch: &str) -> Option<Asset> {
+            let lookup_os = match os {
+                "macos" => "apple-darwin",
+                "linux" => "unknown-linux",
+                _ => return None,
+            };
 
-        let new_exe_path =
-            archive
-                .entries()?
-                .filter_map(|e| e.ok())
-                .find_map(|mut entry| -> Option<PathBuf> {
+            let asset = self
+                .assets
+                .iter()
+                .find(|asset| asset.name.contains(lookup_os) && asset.name.contains(arch))
+                .cloned();
+
+            if asset.is_none() {
+                log::debug!(
+                    "Linkup release for OS '{}' and ARCH '{}' not found on version {}",
+                    lookup_os,
+                    arch,
+                    &self.version
+                );
+            }
+
+            asset
+        }
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct Asset {
+        name: String,
+        #[serde(rename = "browser_download_url")]
+        download_url: String,
+    }
+
+    impl Asset {
+        async fn inner_download(&self) -> Result<PathBuf, Error> {
+            let response = reqwest::get(&self.download_url).await?;
+
+            let file_path = env::temp_dir().join(&self.name);
+            let mut file = fs::File::create(&file_path)?;
+
+            let mut content = std::io::Cursor::new(response.bytes().await?);
+            std::io::copy(&mut content, &mut file)?;
+
+            Ok(file_path)
+        }
+
+        pub async fn download(&self) -> Result<PathBuf, Error> {
+            let filename = "linkup";
+            let file_path = self.inner_download().await?;
+            let file = fs::File::open(&file_path)?;
+
+            let decoder = GzDecoder::new(file);
+            let mut archive = Archive::new(decoder);
+
+            let new_exe_path = archive.entries()?.filter_map(|e| e.ok()).find_map(
+                |mut entry| -> Option<PathBuf> {
                     let entry_path = entry.path().unwrap();
 
-                    if entry_path.to_str().unwrap().contains(lookup_name) {
-                        let path = env::temp_dir().join(lookup_name);
+                    if entry_path.to_str().unwrap().contains(filename) {
+                        let path = env::temp_dir().join(filename);
 
                         entry.unpack(&path).unwrap();
 
@@ -69,288 +102,281 @@ impl Asset {
                     } else {
                         None
                     }
-                });
+                },
+            );
 
-        match new_exe_path {
-            Some(new_exe_path) => Ok(new_exe_path),
-            None => Err(Error::MissingBinary),
+            match new_exe_path {
+                Some(new_exe_path) => Ok(new_exe_path),
+                None => Err(Error::MissingBinary),
+            }
         }
+    }
+
+    pub(super) async fn fetch_stable_release() -> Result<Option<Release>, Error> {
+        let url: Url = "https://api.github.com/repos/mentimeter/linkup/releases/latest"
+            .parse()
+            .expect("GitHub URL to be correct");
+
+        let release = fetch(url).await?;
+
+        Ok(Some(release))
+    }
+
+    pub(super) async fn fetch_beta_release() -> Result<Option<Release>, Error> {
+        let url: Url = "https://api.github.com/repos/mentimeter/linkup/releases"
+            .parse()
+            .expect("GitHub URL to be correct");
+
+        let releases: Vec<Release> = fetch(url).await?;
+
+        let beta_release = releases
+            .into_iter()
+            .find(|release| release.version.starts_with("0.0.0-next-"));
+
+        Ok(beta_release)
+    }
+
+    async fn fetch<T>(url: Url) -> Result<T, Error>
+    where
+        T: DeserializeOwned,
+    {
+        let mut req = reqwest::Request::new(reqwest::Method::GET, url);
+        let headers = req.headers_mut();
+        headers.append("User-Agent", HeaderValue::from_static("linkup-cli"));
+        headers.append(
+            "Accept",
+            HeaderValue::from_static("application/vnd.github+json"),
+        );
+        headers.append(
+            "X-GitHub-Api-Version",
+            HeaderValue::from_static("2022-11-28"),
+        );
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .unwrap();
+
+        let response = client.execute(req).await?;
+
+        if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#checking-the-status-of-your-rate-limit
+            let retry_at = response
+                .headers()
+                .get("x-ratelimit-reset")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or_else(super::next_morning_utc_seconds);
+
+            return Err(Error::RateLimit(retry_at));
+        }
+
+        Ok(response.json::<T>().await?)
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::linkup_file_path;
+use github::Asset;
+use linkup::{Version, VersionChannel};
+
+const CACHE_FILE_NAME: &str = "releases_cache.json";
+
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Release {
-    #[serde(rename = "name")]
-    version: String,
-    assets: Vec<Asset>,
+    pub channel: VersionChannel,
+    pub version: Version,
+    pub binary: Asset,
 }
 
 impl Release {
-    /// Examples of Linkup asset files:
-    /// - linkup-1.7.1-x86_64-apple-darwin.tar.gz
-    /// - linkup-1.7.1-aarch64-apple-darwin.tar.gz
-    /// - linkup-1.7.1-x86_64-unknown-linux-gnu.tar.gz
-    /// - linkup-1.7.1-aarch64-unknown-linux-gnu.tar.gz
-    pub fn linkup_asset(&self, os: &str, arch: &str) -> Option<Asset> {
-        let lookup_os = match os {
-            "macos" => "apple-darwin",
-            "linux" => "unknown-linux",
-            _ => return None,
-        };
+    fn from_github_release(gh_release: &github::Release, os: &str, arch: &str) -> Option<Release> {
+        let version = Version::try_from(gh_release.version.as_str());
+        let asset = gh_release.linkup_asset(os, arch);
 
-        let asset = self
-            .assets
-            .iter()
-            .find(|asset| asset.name.contains(lookup_os) && asset.name.contains(arch))
-            .cloned();
-
-        if asset.is_none() {
-            log::debug!(
-                "Linkup release for OS '{}' and ARCH '{}' not found on version {}",
-                lookup_os,
-                arch,
-                &self.version
-            );
+        match (version, asset) {
+            (Ok(version), Some(asset)) => Some(Release {
+                channel: version.channel(),
+                version,
+                binary: asset,
+            }),
+            _ => None,
         }
-
-        asset
     }
 }
 
 #[derive(Serialize, Deserialize)]
-struct CachedLatestRelease {
-    time: u64,
-    release: Release,
+pub struct CachedReleases {
+    fetched_at: u64,
+    next_fetch_at: u64,
+    releases: Vec<Release>,
 }
 
-pub struct Update {
-    pub version: Version,
-    pub linkup: Asset,
+impl CachedReleases {
+    fn empty_with_retry(retry_at: u64) -> Self {
+        Self {
+            fetched_at: now(),
+            next_fetch_at: retry_at,
+            releases: Vec::default(),
+        }
+    }
+
+    fn cache_path() -> PathBuf {
+        linkup_file_path(CACHE_FILE_NAME)
+    }
+
+    /// Always return the cache only if is "fresh". If the cache is expired, this will delete the
+    /// cache file and return None.
+    fn load() -> Option<Self> {
+        let path = linkup_file_path(CACHE_FILE_NAME);
+        if !path.exists() {
+            return None;
+        }
+
+        let file = match std::fs::File::open(&path) {
+            Ok(file) => file,
+            Err(error) => {
+                log::debug!("failed to open cached latest release file: {}", error);
+
+                return None;
+            }
+        };
+
+        let cache: Self = match serde_json::from_reader(file) {
+            Ok(cache) => cache,
+            Err(error) => {
+                log::debug!("failed to parse cached latest release: {}", error);
+
+                if std::fs::remove_file(&path).is_err() {
+                    log::debug!("failed to delete latest release cache file");
+                }
+
+                return None;
+            }
+        };
+
+        if now() > cache.next_fetch_at {
+            Self::clear();
+
+            return None;
+        }
+
+        Some(cache)
+    }
+
+    fn save(&self) {
+        match std::fs::File::create(linkup_file_path(CACHE_FILE_NAME)) {
+            Ok(new_file) => {
+                if let Err(error) = serde_json::to_writer_pretty(new_file, self) {
+                    log::debug!("failed to write the release data into cache: {}", error);
+                }
+            }
+            Err(error) => {
+                log::debug!("Failed to create release cache file: {}", error);
+            }
+        }
+    }
+
+    pub fn clear() {
+        let path = Self::cache_path();
+        if !path.exists() {
+            return;
+        }
+
+        if let Err(error) = std::fs::remove_file(&path) {
+            log::debug!("failed to delete cached latest release file: {}", error);
+        }
+    }
+
+    fn get_release(&self, channel: VersionChannel) -> Option<&Release> {
+        self.releases
+            .iter()
+            .find(|update| update.channel == channel)
+    }
 }
 
-pub async fn available_update(
+async fn fetch_releases(os: &str, arch: &str) -> Result<Vec<Release>, github::Error> {
+    // TODO: Could we maybe do a single request to GH to list the releases and do the filtering
+    //       locally?
+    let mut releases = Vec::<Release>::with_capacity(2);
+
+    if let Some(stable) = github::fetch_stable_release()
+        .await?
+        .and_then(|gh_release| Release::from_github_release(&gh_release, os, arch))
+    {
+        releases.push(stable);
+    }
+
+    if let Some(beta) = github::fetch_beta_release()
+        .await?
+        .and_then(|gh_release| Release::from_github_release(&gh_release, os, arch))
+    {
+        releases.push(beta);
+    }
+
+    Ok(releases)
+}
+
+pub async fn check_for_update(
     current_version: &Version,
-    desired_channel: Option<linkup::VersionChannel>,
-) -> Option<Update> {
-    let os = env::consts::OS;
-    let arch = env::consts::ARCH;
-
-    let channel = desired_channel.unwrap_or_else(|| current_version.channel());
+    channel: Option<VersionChannel>,
+) -> Option<Release> {
+    let channel = channel.unwrap_or_else(|| current_version.channel());
     log::debug!("Looking for available update on '{channel}' channel.");
 
-    let latest_release = match cached_latest_release(&channel).await {
-        Some(cached_latest_release) => {
-            let release = cached_latest_release.release;
-
-            log::debug!("Found cached release: {}", release.version);
-
-            release
-        }
+    let cached_releases = CachedReleases::load();
+    match cached_releases {
+        Some(cached_releases) => cached_releases.get_release(channel).cloned(),
         None => {
-            log::debug!("No cached release found. Fetching from remote...");
+            let os = std::env::consts::OS;
+            let arch = std::env::consts::ARCH;
 
-            let release = match channel {
-                linkup::VersionChannel::Stable => fetch_stable_release().await,
-                linkup::VersionChannel::Beta => fetch_beta_release().await,
-            };
-
-            let release = match release {
-                Ok(Some(release)) => {
-                    log::debug!("Found release {} on channel '{channel}'.", release.version);
-
-                    release
-                }
-                Ok(None) => {
-                    log::debug!("No release found on remote for channel '{channel}'");
-
-                    return None;
-                }
-                Err(error) => {
-                    log::error!("Failed to fetch the latest release: {}", error);
-
-                    return None;
-                }
-            };
-
-            let cache_file = match channel {
-                VersionChannel::Stable => CACHED_LATEST_STABLE_RELEASE_FILE,
-                VersionChannel::Beta => CACHED_LATEST_BETA_RELEASE_FILE,
-            };
-
-            match fs::File::create(linkup_file_path(cache_file)) {
-                Ok(new_file) => {
-                    let release_cache = CachedLatestRelease {
-                        time: now(),
-                        release,
+            let new_cache = match fetch_releases(os, arch).await {
+                Ok(releases) => {
+                    let cache = CachedReleases {
+                        fetched_at: now(),
+                        next_fetch_at: next_morning_utc_seconds(),
+                        releases,
                     };
 
-                    if let Err(error) = serde_json::to_writer_pretty(new_file, &release_cache) {
-                        log::error!("Failed to write the release data into cache: {}", error);
-                    }
+                    cache.save();
 
-                    release_cache.release
+                    cache
                 }
                 Err(error) => {
-                    log::error!("Failed to create release cache file: {}", error);
+                    let cache = match error {
+                        github::Error::RateLimit(retry_at) => {
+                            CachedReleases::empty_with_retry(retry_at)
+                        }
+                        _ => CachedReleases::empty_with_retry(next_morning_utc_seconds()),
+                    };
 
-                    release
+                    cache.save();
+
+                    cache
                 }
-            }
-        }
-    };
+            };
 
-    let latest_version = match Version::try_from(latest_release.version.as_str()) {
-        Ok(version) => version,
-        Err(error) => {
-            log::error!(
-                "Failed to parse latest version '{}': {}",
-                latest_release.version,
-                error
-            );
-
-            return None;
-        }
-    };
-
-    // Only check the version if the channel is the same.
-    if current_version.channel() == latest_version.channel() && current_version >= &latest_version {
-        log::debug!("Current version ({current_version}) is newer than latest ({latest_version}).");
-
-        return None;
-    }
-
-    let linkup = latest_release
-        .linkup_asset(os, arch)
-        .expect("Linkup asset to be present on a release");
-
-    Some(Update {
-        version: latest_version,
-        linkup,
-    })
-}
-
-async fn fetch_stable_release() -> Result<Option<Release>, reqwest::Error> {
-    let url: Url = "https://api.github.com/repos/mentimeter/linkup/releases/latest"
-        .parse()
-        .unwrap();
-
-    let mut req = reqwest::Request::new(reqwest::Method::GET, url);
-    let headers = req.headers_mut();
-    headers.append("User-Agent", HeaderValue::from_str("linkup-cli").unwrap());
-    headers.append(
-        "Accept",
-        HeaderValue::from_str("application/vnd.github+json").unwrap(),
-    );
-    headers.append(
-        "X-GitHub-Api-Version",
-        HeaderValue::from_str("2022-11-28").unwrap(),
-    );
-
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(1))
-        .build()
-        .unwrap();
-
-    let release = client.execute(req).await?.json().await?;
-
-    Ok(Some(release))
-}
-
-pub async fn fetch_beta_release() -> Result<Option<Release>, reqwest::Error> {
-    let url: Url = "https://api.github.com/repos/mentimeter/linkup/releases"
-        .parse()
-        .unwrap();
-
-    let mut req = reqwest::Request::new(reqwest::Method::GET, url);
-    let headers = req.headers_mut();
-    headers.append("User-Agent", HeaderValue::from_str("linkup-cli").unwrap());
-    headers.append(
-        "Accept",
-        HeaderValue::from_str("application/vnd.github+json").unwrap(),
-    );
-    headers.append(
-        "X-GitHub-Api-Version",
-        HeaderValue::from_str("2022-11-28").unwrap(),
-    );
-
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(1))
-        .build()
-        .unwrap();
-
-    let releases: Vec<Release> = client.execute(req).await?.json().await?;
-
-    let beta_release = releases
-        .into_iter()
-        .find(|release| release.version.starts_with("0.0.0-next-"));
-
-    Ok(beta_release)
-}
-
-async fn cached_latest_release(channel: &VersionChannel) -> Option<CachedLatestRelease> {
-    let file = match channel {
-        VersionChannel::Stable => CACHED_LATEST_STABLE_RELEASE_FILE,
-        VersionChannel::Beta => CACHED_LATEST_STABLE_RELEASE_FILE,
-    };
-
-    let path = linkup_file_path(file);
-    if !path.exists() {
-        return None;
-    }
-
-    let file = match fs::File::open(&path) {
-        Ok(file) => file,
-        Err(error) => {
-            log::error!("Failed to open cached latest release file: {}", error);
-
-            return None;
-        }
-    };
-
-    let cached_latest_release: CachedLatestRelease = match serde_json::from_reader(file) {
-        Ok(cached_latest_release) => cached_latest_release,
-        Err(error) => {
-            log::error!("Failed to parse cached latest release: {}", error);
-
-            if fs::remove_file(&path).is_err() {
-                log::error!("Failed to delete latest release cache file");
-            }
-
-            return None;
-        }
-    };
-
-    let cache_time = Duration::from_secs(cached_latest_release.time);
-    let time_now = Duration::from_secs(now());
-
-    if time_now - cache_time > Duration::from_secs(60 * 60 * 24) {
-        if let Err(error) = fs::remove_file(&path) {
-            log::error!("Failed to delete cached latest release file: {}", error);
-        }
-
-        return None;
-    }
-
-    Some(cached_latest_release)
-}
-
-pub fn clear_cache() {
-    for path in [
-        linkup_file_path(CACHED_LATEST_STABLE_RELEASE_FILE),
-        linkup_file_path(CACHED_LATEST_BETA_RELEASE_FILE),
-    ] {
-        if path.exists() {
-            if let Err(error) = fs::remove_file(&path) {
-                log::error!("Failed to delete release cache file {path:?}: {error}");
-            }
+            new_cache.get_release(channel).cloned()
         }
     }
 }
 
 fn now() -> u64 {
-    let start = time::SystemTime::now();
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("time went backwards")
+        .as_secs()
+}
 
-    let since_the_epoch = start.duration_since(time::UNIX_EPOCH).unwrap();
+fn next_morning_utc_seconds() -> u64 {
+    let seconds_in_day = 60 * 60 * 24;
+    let now_in_seconds = now();
 
-    since_the_epoch.as_secs()
+    let seconds_since_midnight = now_in_seconds % seconds_in_day;
+
+    now_in_seconds + (seconds_in_day - seconds_since_midnight)
 }

--- a/linkup/src/versioning.rs
+++ b/linkup/src/versioning.rs
@@ -1,12 +1,14 @@
 use std::fmt::Display;
 
+use serde::{Deserialize, Serialize};
+
 #[derive(thiserror::Error, Debug)]
 pub enum VersionError {
     #[error("Failed to parse version '{0}'")]
     Parsing(String),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum VersionChannel {
     Stable,
     Beta,
@@ -21,7 +23,7 @@ impl Display for VersionChannel {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Version {
     pub major: u16,
     pub minor: u16,


### PR DESCRIPTION
The main reason that prompted this reimplementation was rate limits from GitHub. If we got rate-limited by GitHub, we should block checking again until the rate limit resets.
The time of when it will be reset is in the header `x-ratelimit-reset`.

Closes SHIP-2147

References:
- https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#checking-the-status-of-your-rate-limit 
