### PR TITLE
fix: Linux installation lifecycle

### DIFF
--- a/linkup-cli/install.py
+++ b/linkup-cli/install.py
@@ -17,6 +17,7 @@ import re
 import shutil
 import subprocess
 import tarfile
+import tempfile
 import urllib.request
 from dataclasses import dataclass
 from enum import Enum
@@ -225,8 +226,9 @@ def download_and_extract(
         sys.exit(1)
 
     print(f"Downloading: {download_url}")
-    local_tar_path = Path("/tmp") / Path(download_url).name
-    local_temp_bin_path = Path("/tmp") / "linkup"
+    temp_dir = Path(tempfile.gettempdir())
+    local_tar_path = temp_dir / Path(download_url).name
+    local_temp_bin_path = temp_dir / "linkup"
 
     try:
         with (
@@ -237,7 +239,7 @@ def download_and_extract(
 
         print(f"Decompressing {local_tar_path}")
         with tarfile.open(local_tar_path, "r:gz") as tar:
-            tar_extract(tar, "/tmp")
+            tar_extract(tar, str(temp_dir))
 
         installation_bin_path = target_location / "linkup"
 

--- a/linkup-cli/install.py
+++ b/linkup-cli/install.py
@@ -171,7 +171,7 @@ def list_releases() -> List[GithubRelease]:
         },
     )
 
-    with urllib.request.urlopen(req) as response:
+    with urllib.request.urlopen(req, timeout=30) as response:
         return [GithubRelease.from_json(release) for release in json.load(response)]
 
 
@@ -184,7 +184,7 @@ def get_latest_stable_release() -> GithubRelease:
         },
     )
 
-    with urllib.request.urlopen(req) as response:
+    with urllib.request.urlopen(req, timeout=30) as response:
         return GithubRelease.from_json(json.load(response))
 
 
@@ -232,7 +232,7 @@ def download_and_extract(
 
     try:
         with (
-            urllib.request.urlopen(download_url) as response,
+            urllib.request.urlopen(download_url, timeout=60) as response,
             open(local_tar_path, "wb") as out_file,
         ):
             shutil.copyfileobj(response, out_file)

--- a/linkup-cli/src/commands/update.rs
+++ b/linkup-cli/src/commands/update.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+#[cfg(not(target_os = "linux"))]
 use std::fs;
 
 use crate::{commands, current_version, linkup_exe_path, release, InstallationMethod, Result};

--- a/linkup-cli/src/commands/update.rs
+++ b/linkup-cli/src/commands/update.rs
@@ -3,6 +3,9 @@ use std::fs;
 
 use crate::{commands, current_version, linkup_exe_path, release, InstallationMethod, Result};
 
+#[cfg(target_os = "linux")]
+use crate::{is_sudo, sudo_su};
+
 #[derive(clap::Args)]
 pub struct Args {
     /// Ignore the cached last version and check remote server again for the latest version.
@@ -61,15 +64,36 @@ pub async fn update(args: &Args) -> Result<()> {
             let current_linkup_path = linkup_exe_path()?;
             let bkp_linkup_path = current_linkup_path.with_extension("bkp");
 
-            fs::rename(&current_linkup_path, &bkp_linkup_path)
-                .expect("failed to move the current exe into a backup");
-            fs::rename(&new_linkup_path, &current_linkup_path)
-                .expect("failed to move the new exe as the current exe");
-
             #[cfg(target_os = "linux")]
             {
                 println!("Linkup needs sudo access to:");
+                println!("  - Update binary in {:?}", &current_linkup_path);
                 println!("  - Add capability to bind to port 80/443");
+
+                if !is_sudo() {
+                    sudo_su()?;
+                }
+
+                std::process::Command::new("sudo")
+                    .args(["mv"])
+                    .arg(&current_linkup_path)
+                    .arg(&bkp_linkup_path)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status()
+                    .expect("failed to move the current exe into a backup");
+
+                std::process::Command::new("sudo")
+                    .args(["mv"])
+                    .arg(&new_linkup_path)
+                    .arg(&current_linkup_path)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status()
+                    .expect("failed to move the new exe as the current exe");
+
                 std::process::Command::new("sudo")
                     .stdout(std::process::Stdio::inherit())
                     .stderr(std::process::Stdio::inherit())
@@ -80,6 +104,14 @@ pub async fn update(args: &Args) -> Result<()> {
                         &current_linkup_path.display().to_string(),
                     ])
                     .spawn()?;
+            }
+
+            #[cfg(not(target_os = "linux"))]
+            {
+                fs::rename(&current_linkup_path, &bkp_linkup_path)
+                    .expect("failed to move the current exe into a backup");
+                fs::rename(&new_linkup_path, &current_linkup_path)
+                    .expect("failed to move the new exe as the current exe");
             }
 
             println!("Finished update!");

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -57,12 +57,6 @@ pub fn linkup_dir_path() -> PathBuf {
     path
 }
 
-pub fn linkup_bin_dir_path() -> PathBuf {
-    let mut path = linkup_dir_path();
-    path.push("bin");
-    path
-}
-
 pub fn linkup_certs_dir_path() -> PathBuf {
     let mut path = linkup_dir_path();
     path.push("certs");


### PR DESCRIPTION
### Description
We are currently installing Linkup under `$HOME/.linkup/bin` for both Linux and MacOS.
The issue with this is that on Linux, we need to use `setcap` to allow the process to bind to process 80/443, which does not work if installed on that location.
On Linux, file capabilities (setcap) only work reliably on files located on a filesystem that supports extended attributes and is mounted with them enabled.

This changes so that we now install on Linux under `/usr/local/bin`. This requires sudo access on installation, uninstallation and update.

This should unblock us to merge #216 

Closes SHIP-2224