### PR TITLE
chore: organize dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -300,7 +299,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -476,7 +474,7 @@ dependencies = [
  "chrono",
  "http",
  "percent-encoding",
- "reqwest 0.12.12",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -815,15 +813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
@@ -1352,7 +1341,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1792,18 +1781,17 @@ dependencies = [
  "http",
  "linkup",
  "linkup-local-server",
- "reqwest 0.12.12",
+ "reqwest 0.13.2",
  "rstest",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.26.1",
+ "tokio-tungstenite 0.28.0",
 ]
 
 [[package]]
 name = "linkup-worker"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "axum 0.8.1",
  "base64",
  "cloudflare",
@@ -1813,12 +1801,10 @@ dependencies = [
  "http",
  "linkup",
  "regex",
- "reqwest 0.12.12",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "tower-service",
- "wasm-bindgen",
- "wasm-bindgen-futures",
  "worker",
 ]
 
@@ -2022,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -2152,9 +2138,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2184,9 +2170,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
@@ -2273,9 +2259,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
@@ -2588,17 +2574,15 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -2606,34 +2590,29 @@ dependencies = [
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
- "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
- "windows-registry",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3241,27 +3220,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3280,16 +3238,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom 0.2.15",
+ "getrandom 0.4.1",
  "once_cell",
- "rustix 0.38.43",
- "windows-sys 0.59.0",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3523,7 +3480,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -3563,7 +3519,6 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -3957,9 +3912,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4136,17 +4100,6 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
  "windows-link",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
-dependencies = [
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,26 @@
 resolver = "2"
 
 members = ["linkup-cli", "linkup", "worker", "local-server", "server-tests", "cloudflare"]
+
+[workspace.dependencies]
+anyhow = "1.0.95"
+async-trait = "0.1.86"
+axum = { version = "0.8.1", default-features = false }
+base64 = "0.22.1"
+futures = "0.3.31"
+hex = "0.4.3"
+http = "1.2.0"
+rand = "0.10.0"
+regex = "1.11.1"
+reqwest = { version = "0.13.2", default-features = false }
+serde = "1.0.217"
+serde_json = "1.0.138"
+sha2 = "0.10.8"
+thiserror = "2.0.11"
+tokio = "1.49.0"
+tokio-tungstenite = "0.28.0"
+url = { version = "2.5.4", features = ["serde"] }
+
+linkup = { path = "linkup" }
+linkup-local-server = { path = "local-server" }
+cloudflare = { path = "cloudflare", default-features = false }

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -9,39 +9,39 @@ name = "linkup"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 clap = { version = "4.5.27", features = ["derive", "cargo"] }
 clap_complete = "4.5.42"
-cloudflare = { path = "../cloudflare", default-features = false, features = [
+cloudflare = { workspace = true, features = [
     "rustls-tls",
 ] }
 colored = "3.0.0"
 ctrlc = { version = "3.4.5", features = ["termination"] }
 hickory-resolver = { version = "0.25.2", features = ["tokio"] }
-linkup = { path = "../linkup" }
-linkup-local-server = { path = "../local-server" }
+linkup = { workspace = true }
+linkup-local-server = { workspace = true }
 log = "0.4.25"
-rand = "0.10.0"
-regex = "1.11.1"
-reqwest = { version = "0.13.2", default-features = false, features = [
+rand = { workspace = true }
+regex = { workspace = true }
+reqwest = { workspace = true, features = [
     "json",
     "multipart",
     "blocking",
     "rustls",
     "query",
 ] }
-serde = "1.0.217"
-serde_json = "1.0.137"
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde_yaml = "0.9.34-deprecated"
-tokio = { version = "1.43.0", features = ["macros"] }
-thiserror = "2.0.11"
-url = { version = "2.5.4", features = ["serde"] }
-base64 = "0.22.1"
+tokio = { workspace = true, features = ["macros"] }
+thiserror = { workspace = true }
+url = { workspace = true }
+base64 = { workspace = true }
 env_logger = "0.11.6"
 crossterm = "0.29.0"
 sysinfo = "0.38.2"
-sha2 = "0.10.8"
-hex = "0.4.3"
+sha2 = { workspace = true }
+hex = { workspace = true }
 tar = "0.4.43"
 flate2 = "1.0.35"
 

--- a/linkup/Cargo.toml
+++ b/linkup/Cargo.toml
@@ -4,16 +4,16 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-hex = "0.4.3"
-rand = "0.10.0"
-regex = "1.11.1"
-serde = "1.0.217"
-serde_json = "1.0.137"
-sha2 = "0.10.8"
-thiserror = "2.0.11"
+hex = { workspace = true }
+rand = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
 unicase = "2.8.1"
-url = { version = "2.5.4", features = ["serde"] }
-http = "1.2.0"
+url = { workspace = true }
+http = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["test-util", "macros"] }
+tokio = { workspace = true, features = ["test-util", "macros"] }

--- a/local-server/Cargo.toml
+++ b/local-server/Cargo.toml
@@ -8,10 +8,10 @@ name = "linkup_local_server"
 path = "src/lib.rs"
 
 [dependencies]
-axum = { version = "0.8.1", features = ["http2", "json", "ws"] }
+axum = { workspace = true, features = ["http2", "json", "ws"] }
 axum-server = { version = "0.8.0", features = ["tls-rustls"] }
-async-trait = "0.1.43"
-http = "1.2.0"
+async-trait = { workspace = true }
+http = { workspace = true }
 hickory-server = { version = "0.25.1", features = ["resolver"] }
 hyper = { version = "1.5.2", features = ["server"] }
 hyper-rustls = { version = "0.27.5", default-features = false, features = [
@@ -19,19 +19,19 @@ hyper-rustls = { version = "0.27.5", default-features = false, features = [
     "ring",
 ] }
 hyper-util = { version = "0.1.10", features = ["client-legacy"] }
-futures = "0.3.31"
-linkup = { path = "../linkup" }
+futures = { workspace = true }
+linkup = { workspace = true }
 rustls = { version = "0.23.37", default-features = false, features = ["ring"] }
 rustls-native-certs = "0.8.1"
-serde = "1.0.217"
-serde_json = "1.0.137"
-thiserror = "2.0.11"
-tokio = { version = "1.49.0", features = [
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = [
     "macros",
     "signal",
     "rt-multi-thread",
 ] }
-tokio-tungstenite = { version = "0.28.0", features = [
+tokio-tungstenite = { workspace = true, features = [
     "rustls-tls-native-roots",
 ] }
 tower-http = { version = "0.6.2", features = ["trace"] }

--- a/server-tests/Cargo.toml
+++ b/server-tests/Cargo.toml
@@ -4,17 +4,17 @@ version = "0.1.0"
 edition = "2024"
 
 [dev-dependencies]
-linkup = { path = "../linkup" }
-linkup-local-server = { path = "../local-server" }
-http = "1.2.0"
-reqwest = { version = "0.12.12", default-features = false, features = [
+linkup = { workspace = true }
+linkup-local-server = { workspace = true }
+http = { workspace = true }
+reqwest = { workspace = true, features = [
     "blocking",
-    "rustls-tls",
+    "rustls",
 ] }
-anyhow = "1.0.95"
-futures = "0.3.31"
-axum = { version = "0.8.1", features = ["ws"] }
-serde_json = "1.0.137"
-tokio-tungstenite = "0.26.1"
-tokio = { version = "1.43.0", features = ["test-util", "macros"] }
+anyhow = { workspace = true }
+futures = { workspace = true }
+axum = { workspace = true, features = ["ws"] }
+serde_json = { workspace = true }
+tokio-tungstenite = { workspace = true }
+tokio = { workspace = true, features = ["test-util", "macros"] }
 rstest = "0.24.0"

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -7,25 +7,20 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-axum = { version = "0.8.1", features = [
+axum = { workspace = true, features = [
     "json",
     "query",
-], default-features = false }
-base64 = "0.22.1"
+] }
+base64 = { workspace = true }
 console_error_panic_hook = { version = "0.1.7" }
-cloudflare = { path = "../cloudflare" }
-futures = "0.3.31"
+cloudflare = { workspace = true, features = ["default-tls"] }
+futures = { workspace = true }
 getrandom = { version = "0.4.1", features = ["wasm_js"] }
-http = "1.2.0"
-linkup = { path = "../linkup" }
-regex = "1.11.1"
-serde = "1"
-serde_json = "1.0.138"
+http = { workspace = true }
+linkup = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tower-service = "0.3.3"
 worker = { version = "0.5.0", features = ["http", "axum"] }
-reqwest = "0.12.12"
-
-# These are required to use worker-rs DurableObjects
-async-trait = "0.1.86"
-wasm-bindgen = "0.2.100"
-wasm-bindgen-futures = "0.4.50"
+reqwest = { workspace = true, features = ["default-tls"] }

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -429,7 +429,7 @@ async fn convert_request(
         .with_redirect(RequestRedirect::Manual);
 
     if !body_bytes.is_empty() {
-        request_init.with_body(Some(wasm_bindgen::JsValue::from_str(
+        request_init.with_body(Some(worker::wasm_bindgen::JsValue::from_str(
             &String::from_utf8_lossy(&body_bytes),
         )));
     }


### PR DESCRIPTION
- Move dependencies that are used on multiple crates to be defined on the workspace (use the highest version).
- Use the exported wasm_bindgen on worker instead of defining dependency.