### PR TITLE
Ensure deterministic session name by sorting session properties

### DIFF
--- a/linkup/src/session.rs
+++ b/linkup/src/session.rs
@@ -257,7 +257,7 @@ impl TryFrom<serde_json::Value> for Session {
 
 impl From<Session> for StorableSession {
     fn from(value: Session) -> Self {
-        let services: Vec<StorableService> = value
+        let mut services: Vec<StorableService> = value
             .services
             .into_iter()
             .map(|(name, service)| {
@@ -284,7 +284,9 @@ impl From<Session> for StorableSession {
             })
             .collect();
 
-        let domains: Vec<StorableDomain> = value
+        services.sort_by(|a, b| a.name.cmp(&b.name));
+
+        let mut domains: Vec<StorableDomain> = value
             .domains
             .into_iter()
             .map(|(domain, domain_data)| {
@@ -311,6 +313,8 @@ impl From<Session> for StorableSession {
                 }
             })
             .collect();
+
+        domains.sort_by(|a, b| a.domain.cmp(&b.domain));
 
         let cache_routes = value.cache_routes.map(|cr| {
             cr.into_iter()

--- a/linkup/src/session_allocator.rs
+++ b/linkup/src/session_allocator.rs
@@ -164,3 +164,56 @@ impl<'a, S: StringStore> SessionAllocator<'a, S> {
         Ok(random_six_char())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{create_preview_req_from_json, MemoryStringStore};
+
+    #[tokio::test]
+    async fn identical_preview_requests_reuse_same_name() {
+        let store = MemoryStringStore::default();
+        let allocator = SessionAllocator::new(&store);
+        let request_json = serde_json::json!({
+            "services": [
+                {
+                    "name": "frontend",
+                    "location": "https://frontend.example.com"
+                },
+                {
+                    "name": "backend",
+                    "location": "https://backend.example.com"
+                }
+            ],
+            "domains": [
+                {
+                    "domain": "example.com",
+                    "default_service": "frontend",
+                    "routes": [
+                        {
+                            "path": "^/api(?:/|$)",
+                            "service": "backend"
+                        }
+                    ]
+                }
+            ],
+            "cache_routes": null
+        })
+        .to_string();
+
+        let first_session = create_preview_req_from_json(request_json.clone()).unwrap();
+        let second_session = create_preview_req_from_json(request_json).unwrap();
+
+        let first_name = allocator
+            .store_session(first_session, NameKind::SixChar, String::new())
+            .await
+            .unwrap();
+        let second_name = allocator
+            .store_session(second_session, NameKind::SixChar, String::new())
+            .await
+            .unwrap();
+
+        assert_eq!(first_name.len(), 6);
+        assert_eq!(first_name, second_name);
+    }
+}


### PR DESCRIPTION
@augustoccesar - has been tearing my hair out that the names change on redeploy, this seems to be the cause.

Happened because these properties came through unsorted HashMaps before they got here.