### PR TITLE
feat: create linkup-clients crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,6 +1758,7 @@ dependencies = [
  "hickory-resolver",
  "indicatif",
  "linkup",
+ "linkup-clients",
  "linkup-local-server",
  "log",
  "mockall",
@@ -1773,6 +1774,18 @@ dependencies = [
  "tar",
  "thiserror 2.0.11",
  "tokio",
+ "url",
+]
+
+[[package]]
+name = "linkup-clients"
+version = "0.1.0"
+dependencies = [
+ "linkup",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 
-members = ["linkup-cli", "linkup", "worker", "local-server", "server-tests", "cloudflare"]
+members = ["linkup-cli", "linkup", "linkup-clients", "worker", "local-server", "server-tests", "cloudflare"]
 
 [workspace.dependencies]
 anyhow = "1.0.95"
@@ -23,5 +23,6 @@ tokio-tungstenite = "0.28.0"
 url = { version = "2.5.4", features = ["serde"] }
 
 linkup = { path = "linkup" }
+linkup-clients = { path = "linkup-clients" }
 linkup-local-server = { path = "local-server" }
 cloudflare = { path = "cloudflare", default-features = false }

--- a/linkup-cli/Cargo.toml
+++ b/linkup-cli/Cargo.toml
@@ -19,6 +19,7 @@ colored = "3.0.0"
 ctrlc = { version = "3.4.5", features = ["termination"] }
 hickory-resolver = { version = "0.25.2", features = ["tokio"] }
 linkup = { workspace = true }
+linkup-clients = { workspace = true }
 linkup-local-server = { workspace = true }
 log = "0.4.25"
 rand = { workspace = true }

--- a/linkup-cli/src/commands/preview.rs
+++ b/linkup-cli/src/commands/preview.rs
@@ -1,6 +1,6 @@
+use crate::Result;
 use crate::commands::status::{SessionStatus, format_state_domains};
 use crate::state::{config_path, get_config};
-use crate::{CURRENT_VERSION, Result};
 use anyhow::Context;
 use clap::builder::ValueParser;
 use linkup::UpsertSessionRequest;
@@ -37,7 +37,7 @@ pub async fn preview(args: &Args, config: &Option<String>) -> Result<()> {
         return Ok(());
     }
 
-    let preview_name = WorkerClient::new(&url, &input_config.linkup.worker_token, CURRENT_VERSION)
+    let preview_name = WorkerClient::new(&url, &input_config.linkup.worker_token)
         .preview_session(&upsert_session_request)
         .await
         .with_context(|| format!("Failed to send preview request to {}", url))?;

--- a/linkup-cli/src/commands/preview.rs
+++ b/linkup-cli/src/commands/preview.rs
@@ -1,6 +1,6 @@
-use crate::{CURRENT_VERSION, Result};
 use crate::commands::status::{SessionStatus, format_state_domains};
 use crate::state::{config_path, get_config};
+use crate::{CURRENT_VERSION, Result};
 use anyhow::Context;
 use clap::builder::ValueParser;
 use linkup::UpsertSessionRequest;

--- a/linkup-cli/src/commands/preview.rs
+++ b/linkup-cli/src/commands/preview.rs
@@ -1,10 +1,10 @@
-use crate::Result;
+use crate::{CURRENT_VERSION, Result};
 use crate::commands::status::{SessionStatus, format_state_domains};
 use crate::state::{config_path, get_config};
-use crate::worker_client::WorkerClient;
 use anyhow::Context;
 use clap::builder::ValueParser;
 use linkup::UpsertSessionRequest;
+use linkup_clients::WorkerClient;
 use url::Url;
 
 #[derive(clap::Args)]
@@ -37,8 +37,8 @@ pub async fn preview(args: &Args, config: &Option<String>) -> Result<()> {
         return Ok(());
     }
 
-    let preview_name = WorkerClient::from(&input_config)
-        .preview(&upsert_session_request)
+    let preview_name = WorkerClient::new(&url, &input_config.linkup.worker_token, CURRENT_VERSION)
+        .preview_session(&upsert_session_request)
         .await
         .with_context(|| format!("Failed to send preview request to {}", url))?;
 

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -13,7 +13,6 @@ mod env_files;
 mod release;
 mod services;
 mod state;
-mod worker_client;
 
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const LINKUP_CONFIG_ENV: &str = "LINKUP_CONFIG";

--- a/linkup-cli/src/services/cloudflare_tunnel.rs
+++ b/linkup-cli/src/services/cloudflare_tunnel.rs
@@ -14,7 +14,9 @@ use serde::{Deserialize, Serialize};
 use tokio::time::sleep;
 use url::Url;
 
-use crate::{Result, linkup_file_path, state::State, worker_client::WorkerClient};
+use linkup_clients::WorkerClient;
+
+use crate::{CURRENT_VERSION, Result, linkup_file_path, state::State};
 
 use super::{BackgroundService, PidError};
 
@@ -66,7 +68,7 @@ impl CloudflareTunnel {
             linkup_session_name
         );
 
-        let worker_client = WorkerClient::new(worker_url, worker_token);
+        let worker_client = WorkerClient::new(worker_url, worker_token, CURRENT_VERSION);
         let tunnel_data = worker_client
             .get_tunnel(linkup_session_name)
             .await

--- a/linkup-cli/src/services/cloudflare_tunnel.rs
+++ b/linkup-cli/src/services/cloudflare_tunnel.rs
@@ -16,7 +16,7 @@ use url::Url;
 
 use linkup_clients::WorkerClient;
 
-use crate::{CURRENT_VERSION, Result, linkup_file_path, state::State};
+use crate::{Result, linkup_file_path, state::State};
 
 use super::{BackgroundService, PidError};
 
@@ -68,7 +68,7 @@ impl CloudflareTunnel {
             linkup_session_name
         );
 
-        let worker_client = WorkerClient::new(worker_url, worker_token, CURRENT_VERSION);
+        let worker_client = WorkerClient::new(worker_url, worker_token);
         let tunnel_data = worker_client
             .get_tunnel(linkup_session_name)
             .await

--- a/linkup-cli/src/services/local_server.rs
+++ b/linkup-cli/src/services/local_server.rs
@@ -9,14 +9,13 @@ use std::{
 
 use anyhow::Context;
 use indicatif::ProgressBar;
-use reqwest::StatusCode;
+use linkup_clients::LocalServerClient;
 use tokio::time::sleep;
 use url::Url;
 
 use crate::{
     Result, linkup_certs_dir_path, linkup_file_path,
     state::{State, upload_state},
-    worker_client,
 };
 
 use super::{BackgroundService, PidError};
@@ -29,8 +28,6 @@ pub enum Error {
     StoppingPid(#[from] PidError),
     #[error("Failed to reach the local server")]
     ServerUnreachable,
-    #[error("WorkerClient error: {0}")]
-    WorkerClient(#[from] worker_client::Error),
 }
 
 pub struct LocalServer {
@@ -82,15 +79,10 @@ impl LocalServer {
     }
 
     async fn reachable(&self) -> bool {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(1))
-            .build()
-            .expect("failed while creating an HTTP client to check readiness of LocalServer");
-
-        let url = format!("{}linkup/check", Self::url());
-        let response = client.get(url).send().await;
-
-        matches!(response, Ok(res) if res.status() == StatusCode::OK)
+        matches!(
+            LocalServerClient::new(&Self::url()).health_check().await,
+            Ok(true)
+        )
     }
 
     async fn update_state(&self, state: &mut State) -> Result<()> {

--- a/linkup-cli/src/state.rs
+++ b/linkup-cli/src/state.rs
@@ -12,10 +12,9 @@ use url::Url;
 
 use linkup::{Domain, Session, SessionService, UpsertSessionRequest};
 
-use crate::{
-    LINKUP_CONFIG_ENV, LINKUP_STATE_FILE, Result, linkup_file_path, services,
-    worker_client::{self, WorkerClient},
-};
+use linkup_clients::{LocalServerClient, WorkerClient};
+
+use crate::{LINKUP_CONFIG_ENV, LINKUP_STATE_FILE, CURRENT_VERSION, Result, linkup_file_path, services};
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct State {
@@ -198,7 +197,7 @@ pub async fn upload_state(state: &State) -> Result<String> {
     let servers_sessions = ServersSessions::from(state);
     let session_name = &state.linkup.session_name;
 
-    let server_session_name = upload_session_to_server(
+    let server_session_name = upload_session_to_worker(
         &state.linkup.worker_url,
         &state.linkup.worker_token,
         session_name,
@@ -206,13 +205,9 @@ pub async fn upload_state(state: &State) -> Result<String> {
     )
     .await?;
 
-    let local_session_name = upload_session_to_server(
-        &local_url,
-        &state.linkup.worker_token,
-        &server_session_name,
-        servers_sessions.local,
-    )
-    .await?;
+    let local_session_name =
+        upload_session_to_local_server(&local_url, &server_session_name, servers_sessions.local)
+            .await?;
 
     if server_session_name != local_session_name {
         log::error!(
@@ -221,31 +216,45 @@ pub async fn upload_state(state: &State) -> Result<String> {
             &server_session_name
         );
 
-        return Err(worker_client::Error::InconsistentState.into());
+        return Err(anyhow::anyhow!(
+            "your session is in an inconsistent state. Stop your session before trying again."
+        ));
     }
 
     Ok(server_session_name)
 }
 
-async fn upload_session_to_server(
-    linkup_url: &Url,
-    worker_token: &str,
+async fn upload_session_to_worker(
+    url: &Url,
+    token: &str,
     desired_name: &str,
     session: Session,
-) -> Result<String, worker_client::Error> {
-    let session_update_req = UpsertSessionRequest::Named {
+) -> Result<String> {
+    let req = build_upsert_request(desired_name, session);
+
+    Ok(WorkerClient::new(url, token, CURRENT_VERSION)
+        .local_session(&req)
+        .await?)
+}
+
+async fn upload_session_to_local_server(
+    url: &Url,
+    desired_name: &str,
+    session: Session,
+) -> Result<String> {
+    let req = build_upsert_request(desired_name, session);
+
+    Ok(LocalServerClient::new(url).upsert_session(&req).await?)
+}
+
+fn build_upsert_request(desired_name: &str, session: Session) -> UpsertSessionRequest {
+    UpsertSessionRequest::Named {
         session_token: session.session_token,
         desired_name: desired_name.to_string(),
         services: session.services,
         domains: session.domains,
         cache_routes: session.cache_routes,
-    };
-
-    let session_name = WorkerClient::new(linkup_url, worker_token)
-        .linkup(&session_update_req)
-        .await?;
-
-    Ok(session_name)
+    }
 }
 
 impl From<&State> for ServersSessions {

--- a/linkup-cli/src/state.rs
+++ b/linkup-cli/src/state.rs
@@ -14,9 +14,7 @@ use linkup::{Domain, Session, SessionService, UpsertSessionRequest};
 
 use linkup_clients::{LocalServerClient, WorkerClient};
 
-use crate::{
-    CURRENT_VERSION, LINKUP_CONFIG_ENV, LINKUP_STATE_FILE, Result, linkup_file_path, services,
-};
+use crate::{LINKUP_CONFIG_ENV, LINKUP_STATE_FILE, Result, linkup_file_path, services};
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct State {
@@ -234,9 +232,7 @@ async fn upload_session_to_worker(
 ) -> Result<String> {
     let req = build_upsert_request(desired_name, session);
 
-    Ok(WorkerClient::new(url, token, CURRENT_VERSION)
-        .local_session(&req)
-        .await?)
+    Ok(WorkerClient::new(url, token).local_session(&req).await?)
 }
 
 async fn upload_session_to_local_server(

--- a/linkup-cli/src/state.rs
+++ b/linkup-cli/src/state.rs
@@ -14,7 +14,9 @@ use linkup::{Domain, Session, SessionService, UpsertSessionRequest};
 
 use linkup_clients::{LocalServerClient, WorkerClient};
 
-use crate::{LINKUP_CONFIG_ENV, LINKUP_STATE_FILE, CURRENT_VERSION, Result, linkup_file_path, services};
+use crate::{
+    CURRENT_VERSION, LINKUP_CONFIG_ENV, LINKUP_STATE_FILE, Result, linkup_file_path, services,
+};
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct State {

--- a/linkup-clients/Cargo.toml
+++ b/linkup-clients/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "linkup-clients"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+linkup = { workspace = true }
+reqwest = { workspace = true, features = ["rustls"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+url = { workspace = true }

--- a/linkup-clients/src/lib.rs
+++ b/linkup-clients/src/lib.rs
@@ -1,0 +1,5 @@
+mod local_server;
+mod worker;
+
+pub use local_server::{Error as LocalServerError, LocalServerClient};
+pub use worker::{Error as WorkerError, TunnelData, WorkerClient};

--- a/linkup-clients/src/local_server.rs
+++ b/linkup-clients/src/local_server.rs
@@ -1,0 +1,71 @@
+use std::time::Duration;
+
+use linkup::UpsertSessionRequest;
+use reqwest::StatusCode;
+use serde::Serialize;
+use url::Url;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("{0}")]
+    Reqwest(#[from] reqwest::Error),
+    #[error("{0}")]
+    UrlParse(#[from] url::ParseError),
+    #[error("{0}")]
+    Serde(#[from] serde_json::Error),
+    #[error("request failed with status {0}: {1}")]
+    Response(StatusCode, String),
+}
+
+pub struct LocalServerClient {
+    url: Url,
+    inner: reqwest::Client,
+}
+
+impl LocalServerClient {
+    pub fn new(url: &Url) -> Self {
+        Self {
+            url: url.clone(),
+            inner: reqwest::Client::new(),
+        }
+    }
+
+    pub async fn health_check(&self) -> Result<bool, Error> {
+        let endpoint = self.url.join("/linkup/check")?;
+
+        let response = self
+            .inner
+            .get(endpoint)
+            .timeout(Duration::from_secs(1))
+            .send()
+            .await?;
+
+        Ok(matches!(response, res if res.status() == StatusCode::OK))
+    }
+
+    pub async fn upsert_session(&self, params: &UpsertSessionRequest) -> Result<String, Error> {
+        self.post("/linkup/local-session", params).await
+    }
+
+    async fn post<T: Serialize>(&self, path: &str, params: &T) -> Result<String, Error> {
+        let params = serde_json::to_string(params)?;
+        let endpoint = self.url.join(path)?;
+        let response = self
+            .inner
+            .post(endpoint)
+            .header("Content-Type", "application/json")
+            .body(params)
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            let content = response.text().await?;
+            Ok(content)
+        } else {
+            Err(Error::Response(
+                response.status(),
+                response.text().await.unwrap_or_else(|_| "".to_string()),
+            ))
+        }
+    }
+}

--- a/linkup-clients/src/worker.rs
+++ b/linkup-clients/src/worker.rs
@@ -13,8 +13,6 @@ pub enum Error {
     Serde(#[from] serde_json::Error),
     #[error("request failed with status {0}: {1}")]
     Response(StatusCode, String),
-    #[error("your session is in an inconsistent state. Stop your session before trying again.")]
-    InconsistentState,
 }
 
 pub struct WorkerClient {
@@ -40,15 +38,17 @@ struct GetTunnelParams {
 }
 
 impl WorkerClient {
-    pub fn new(url: &Url, worker_token: &str) -> Self {
+    pub fn new(url: &Url, worker_token: &str, version: &str) -> Self {
         let mut headers = header::HeaderMap::new();
         let mut auth_value = header::HeaderValue::from_str(&format!("Bearer {}", worker_token))
             .expect("token to contain only valid bytes");
+
         auth_value.set_sensitive(true);
+
         headers.insert(header::AUTHORIZATION, auth_value);
         headers.insert(
             "x-linkup-version",
-            header::HeaderValue::from_static(crate::CURRENT_VERSION),
+            header::HeaderValue::from_str(version).expect("version should be valid str"),
         );
 
         let client = reqwest::Client::builder()
@@ -62,12 +62,12 @@ impl WorkerClient {
         }
     }
 
-    pub async fn preview(&self, params: &UpsertSessionRequest) -> Result<String, Error> {
-        self.post("/linkup/preview-session", params).await
+    pub async fn local_session(&self, params: &UpsertSessionRequest) -> Result<String, Error> {
+        self.post("/linkup/local-session", params).await
     }
 
-    pub async fn linkup(&self, params: &UpsertSessionRequest) -> Result<String, Error> {
-        self.post("/linkup/local-session", params).await
+    pub async fn preview_session(&self, params: &UpsertSessionRequest) -> Result<String, Error> {
+        self.post("/linkup/preview-session", params).await
     }
 
     pub async fn get_tunnel(&self, session_name: &str) -> Result<TunnelData, Error> {
@@ -110,11 +110,5 @@ impl WorkerClient {
                 response.text().await.unwrap_or_else(|_| "".to_string()),
             ))
         }
-    }
-}
-
-impl From<&linkup::config::Config> for WorkerClient {
-    fn from(config: &linkup::config::Config) -> Self {
-        Self::new(&config.linkup.worker_url, &config.linkup.worker_token)
     }
 }

--- a/linkup-clients/src/worker.rs
+++ b/linkup-clients/src/worker.rs
@@ -38,7 +38,7 @@ struct GetTunnelParams {
 }
 
 impl WorkerClient {
-    pub fn new(url: &Url, worker_token: &str, version: &str) -> Self {
+    pub fn new(url: &Url, worker_token: &str) -> Self {
         let mut headers = header::HeaderMap::new();
         let mut auth_value = header::HeaderValue::from_str(&format!("Bearer {}", worker_token))
             .expect("token to contain only valid bytes");
@@ -48,7 +48,7 @@ impl WorkerClient {
         headers.insert(header::AUTHORIZATION, auth_value);
         headers.insert(
             "x-linkup-version",
-            header::HeaderValue::from_str(version).expect("version should be valid str"),
+            header::HeaderValue::from_static(CURRENT_VERSION),
         );
 
         let client = reqwest::Client::builder()
@@ -112,3 +112,5 @@ impl WorkerClient {
         }
     }
 }
+
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
This new crate have the clients for both the worker and the local-server.