### PR TITLE
feat: improvements and small fixes on update flow

### DIFF
--- a/.github/workflows/cleanup-next-releases.yml
+++ b/.github/workflows/cleanup-next-releases.yml
@@ -1,0 +1,52 @@
+name: Cleanup Old Next Releases
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
+
+jobs:
+  cleanup:
+    name: Delete all next pre-releases except the latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old next pre-releases
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const nextReleases = releases
+              .filter(r => r.prerelease && r.tag_name.startsWith('0.0.0-next-'))
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+            const [latest, ...old] = nextReleases;
+
+            if (latest) {
+              core.info(`Keeping latest release: ${latest.tag_name}`);
+            } else {
+              core.info('No next releases found.');
+
+              return;
+            }
+
+            for (const release of old) {
+              core.info(`Deleting release: ${release.tag_name}`);
+
+              await github.rest.repos.deleteRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: release.id,
+              });
+
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `tags/${release.tag_name}`,
+              });
+            }
+
+            core.info(`Cleaned up ${old.length} old next release(s).`);

--- a/linkup-cli/src/commands/update.rs
+++ b/linkup-cli/src/commands/update.rs
@@ -105,6 +105,15 @@ pub async fn update(args: &Args) -> Result<()> {
                         &current_linkup_path.display().to_string(),
                     ])
                     .spawn()?;
+
+                std::process::Command::new("sudo")
+                    .args(["rm", "-f"])
+                    .arg(&bkp_linkup_path)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status()
+                    .expect("failed to remove backup exe");
             }
 
             #[cfg(not(target_os = "linux"))]
@@ -113,6 +122,7 @@ pub async fn update(args: &Args) -> Result<()> {
                     .expect("failed to move the current exe into a backup");
                 fs::rename(&new_linkup_path, &current_linkup_path)
                     .expect("failed to move the new exe as the current exe");
+                fs::remove_file(&bkp_linkup_path).expect("failed to remove backup exe");
             }
 
             println!("Finished update!");

--- a/linkup-cli/src/release.rs
+++ b/linkup-cli/src/release.rs
@@ -291,10 +291,10 @@ impl CachedReleases {
         }
     }
 
-    fn get_release(&self, channel: VersionChannel) -> Option<&Release> {
+    fn get_release(&self, channel: &VersionChannel) -> Option<&Release> {
         self.releases
             .iter()
-            .find(|update| update.channel == channel)
+            .find(|update| &update.channel == channel)
     }
 }
 
@@ -329,7 +329,7 @@ pub async fn check_for_update(
 
     let cached_releases = CachedReleases::load();
     let release = match cached_releases {
-        Some(cached_releases) => cached_releases.get_release(channel).cloned(),
+        Some(cached_releases) => cached_releases.get_release(&channel).cloned(),
         None => {
             let os = std::env::consts::OS;
             let arch = std::env::consts::ARCH;
@@ -360,11 +360,13 @@ pub async fn check_for_update(
                 }
             };
 
-            new_cache.get_release(channel).cloned()
+            new_cache.get_release(&channel).cloned()
         }
     };
 
-    release.filter(|release| &release.version > current_version)
+    release.filter(|release| {
+        channel != current_version.channel() || &release.version > current_version
+    })
 }
 
 fn now() -> u64 {

--- a/linkup-cli/src/release.rs
+++ b/linkup-cli/src/release.rs
@@ -117,9 +117,7 @@ mod github {
             .parse()
             .expect("GitHub URL to be correct");
 
-        let release = fetch(url).await?;
-
-        Ok(Some(release))
+        fetch(url).await
     }
 
     pub(super) async fn fetch_beta_release() -> Result<Option<Release>, Error> {
@@ -127,7 +125,7 @@ mod github {
             .parse()
             .expect("GitHub URL to be correct");
 
-        let releases: Vec<Release> = fetch(url).await?;
+        let releases: Vec<Release> = fetch(url).await?.unwrap_or_default();
 
         let beta_release = releases
             .into_iter()
@@ -136,7 +134,7 @@ mod github {
         Ok(beta_release)
     }
 
-    async fn fetch<T>(url: Url) -> Result<T, Error>
+    async fn fetch<T>(url: Url) -> Result<Option<T>, Error>
     where
         T: DeserializeOwned,
     {
@@ -159,6 +157,10 @@ mod github {
 
         let response = client.execute(req).await?;
 
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
         if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
             // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#checking-the-status-of-your-rate-limit
             let retry_at = response
@@ -171,7 +173,7 @@ mod github {
             return Err(Error::RateLimit(retry_at));
         }
 
-        Ok(response.json::<T>().await?)
+        Ok(Some(response.json::<T>().await?))
     }
 }
 


### PR DESCRIPTION
Main changes here are:
- 167422eb77b970382598146be0bdc4f08a90d061 Ensure that if changing channel, consider a valid update regardless of the version. Since beta channel (`next` branch) always have version `0.0.0-*`, it always consider there is no update when doing `linkup update --channel beta` from stable.
- acfd2b0031688408f45568e83a1e39a736e7c4b4 Add a weekly workflow to cleanup old `next` versions. 

Other fixes:
- affa3f55a08c0fbbebe64bf91db8fb0c5369fac1 Cleanup backup local file after update finishes.
- b96e26404524d52a979a62b786d227b8dbbae4c4 Handle 404's as `None` when fetching releases.

Closes SHIP-2636