### PR TITLE
feat: block commands when local server is unreachable

### DIFF
--- a/linkup-cli/src/commands/local.rs
+++ b/linkup-cli/src/commands/local.rs
@@ -31,17 +31,7 @@ pub async fn local(args: &Args) -> Result<()> {
         return Err(anyhow!("No service names provided"));
     }
 
-    if !State::exists() {
-        println!(
-            "{}",
-            "Seems like you don't have any state yet to point to local.".yellow()
-        );
-        println!("{}", "Have you run 'linkup start' at least once?".yellow());
-
-        return Ok(());
-    }
-
-    if services::local_server::find_pid().is_none() {
+    if !services::local_server::is_reachable().await {
         println!(
             "{}",
             "Seems like your local Linkup server is not running. Please run 'linkup start' first."

--- a/linkup-cli/src/commands/remote.rs
+++ b/linkup-cli/src/commands/remote.rs
@@ -31,17 +31,7 @@ pub async fn remote(args: &Args) -> Result<()> {
         return Err(anyhow!("No service names provided"));
     }
 
-    if !State::exists() {
-        println!(
-            "{}",
-            "Seems like you don't have any state yet to point to remote.".yellow()
-        );
-        println!("{}", "Have you run 'linkup start' at least once?".yellow());
-
-        return Ok(());
-    }
-
-    if services::local_server::find_pid().is_none() {
+    if !services::local_server::is_reachable().await {
         println!(
             "{}",
             "Seems like your local Linkup server is not running. Please run 'linkup start' first."

--- a/linkup-cli/src/commands/sessions/create_isolated.rs
+++ b/linkup-cli/src/commands/sessions/create_isolated.rs
@@ -18,7 +18,7 @@ pub(super) struct Args {
 }
 
 pub(super) async fn run(args: &Args, config: &Option<String>) -> Result<()> {
-    if local_server::find_pid().is_none() {
+    if !local_server::is_reachable().await {
         println!(
             "{}",
             "Seems like your local Linkup server is not running. Please run 'linkup start' first."

--- a/linkup-cli/src/commands/sessions/delete.rs
+++ b/linkup-cli/src/commands/sessions/delete.rs
@@ -12,14 +12,7 @@ pub struct Args {
 }
 
 pub async fn run(args: &Args) -> Result<()> {
-    if !State::exists() {
-        println!("{}", "Seems like you don't have any state yet.".yellow());
-        println!("{}", "Have you run 'linkup start' at least once?".yellow());
-
-        return Ok(());
-    }
-
-    if local_server::find_pid().is_none() {
+    if !local_server::is_reachable().await {
         println!(
             "{}",
             "Seems like your local Linkup server is not running. Please run 'linkup start' first."

--- a/linkup-cli/src/commands/start.rs
+++ b/linkup-cli/src/commands/start.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::{Context, anyhow};
 use linkup::SessionKind;
 
-use crate::{Result, state::State};
+use crate::{Result, services::local_server, state::State};
 use crate::{
     env_files::write_to_env_file,
     services,
@@ -25,7 +25,7 @@ pub struct Args {
 
 pub async fn start(args: &Args, config_arg: &Option<String>) -> Result<()> {
     if let Ok(existing) = State::load()
-        && services::local_server::find_pid().is_some()
+        && local_server::is_reachable().await
     {
         let requested = if args.isolated {
             SessionKind::Isolated

--- a/linkup-cli/src/commands/status/mod.rs
+++ b/linkup-cli/src/commands/status/mod.rs
@@ -15,7 +15,8 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::{
-    commands, services,
+    commands,
+    services::{self, local_server},
     session::{SessionRow, format_state_domains, print_sessions_table},
     state::{State, get_config},
 };
@@ -36,12 +37,12 @@ pub struct Args {
 }
 
 pub async fn status(args: &Args) -> anyhow::Result<()> {
-    if !State::exists() {
+    if !local_server::is_reachable().await {
         println!(
             "{}",
-            "Seems like you don't have any state yet, so there is no status to report.".yellow()
+            "Seems like your local Linkup server is not running. Please run 'linkup start' first."
+                .yellow()
         );
-        println!("{}", "Have you run 'linkup start' at least once?".yellow());
 
         return Ok(());
     }

--- a/linkup-cli/src/services/local_server.rs
+++ b/linkup-cli/src/services/local_server.rs
@@ -80,7 +80,7 @@ pub fn find_pid() -> Option<Pid> {
     super::find_pid(ID)
 }
 
-async fn is_reachable() -> bool {
+pub async fn is_reachable() -> bool {
     matches!(
         LocalServerClient::new(&url()).health_check().await,
         Ok(true)


### PR DESCRIPTION
Blocks the following from being ran when Linkup local server is not reachable, instead of simply checking if the process is running:
- `sessions create-isolated`
- `sessions delete`
- `status`
- `local`
- `remote`

Closes SHIP-2632