### PR TITLE
feat: add command to list sessions

### DIFF
--- a/linkup-cli/src/commands/sessions/list.rs
+++ b/linkup-cli/src/commands/sessions/list.rs
@@ -7,9 +7,12 @@ use crate::{
 };
 
 #[derive(clap::Args)]
-pub struct Args {}
+pub struct Args {
+    #[arg(long)]
+    pub json: bool,
+}
 
-pub async fn run(_args: &Args) -> Result<()> {
+pub async fn run(args: &Args) -> Result<()> {
     if !local_server::is_reachable().await {
         println!(
             "{}",
@@ -20,7 +23,17 @@ pub async fn run(_args: &Args) -> Result<()> {
         return Ok(());
     }
 
-    print_sessions_table(&list_session_rows().await, None);
+    let sessions_rows = list_session_rows().await;
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&sessions_rows)
+                .expect("Failed to serialize sessions rows")
+        );
+    } else {
+        print_sessions_table(&sessions_rows, None);
+    }
 
     Ok(())
 }

--- a/linkup-cli/src/commands/sessions/list.rs
+++ b/linkup-cli/src/commands/sessions/list.rs
@@ -1,0 +1,26 @@
+use colored::Colorize;
+
+use crate::{
+    Result,
+    services::local_server,
+    session::{list_session_rows, print_sessions_table},
+};
+
+#[derive(clap::Args)]
+pub struct Args {}
+
+pub async fn run(_args: &Args) -> Result<()> {
+    if !local_server::is_reachable().await {
+        println!(
+            "{}",
+            "Seems like your local Linkup server is not running. Please run 'linkup start' first."
+                .yellow()
+        );
+
+        return Ok(());
+    }
+
+    print_sessions_table(&list_session_rows().await, None);
+
+    Ok(())
+}

--- a/linkup-cli/src/commands/sessions/mod.rs
+++ b/linkup-cli/src/commands/sessions/mod.rs
@@ -1,6 +1,7 @@
 mod create_isolated;
 mod create_preview;
 mod delete;
+mod list;
 
 use clap::Subcommand;
 
@@ -22,6 +23,9 @@ enum Command {
 
     #[clap(about = "Delete session")]
     Delete(delete::Args),
+
+    #[clap(about = "List sessions", aliases = ["ls"])]
+    List(list::Args),
 }
 
 pub async fn sessions(args: &Args, config: &Option<String>) -> Result<()> {
@@ -29,5 +33,6 @@ pub async fn sessions(args: &Args, config: &Option<String>) -> Result<()> {
         Command::CreatePreview(args) => create_preview::run(args, config).await,
         Command::CreateIsolated(args) => create_isolated::run(args, config).await,
         Command::Delete(args) => delete::run(args).await,
+        Command::List(args) => list::run(args).await,
     }
 }

--- a/linkup-cli/src/commands/status/mod.rs
+++ b/linkup-cli/src/commands/status/mod.rs
@@ -17,7 +17,7 @@ use url::Url;
 use crate::{
     commands,
     services::{self, local_server},
-    session::{SessionRow, format_state_domains, print_sessions_table},
+    session::{SessionRow, list_session_rows, print_sessions_table},
     state::{State, get_config},
 };
 
@@ -55,7 +55,7 @@ pub async fn status(args: &Args) -> anyhow::Result<()> {
         .unwrap_or(&state.linkup.session_name)
         .to_string();
 
-    let all_sessions = fetch_sessions().await;
+    let all_sessions = list_session_rows().await;
 
     if args.session.is_some()
         && !all_sessions
@@ -197,32 +197,6 @@ struct Output {
     session_name: String,
     sessions: Vec<SessionRow>,
     services: Vec<ServiceStatus>,
-}
-
-async fn fetch_sessions() -> Vec<SessionRow> {
-    let client = LocalServerClient::new(&services::local_server::url());
-
-    match client.list_sessions().await {
-        Ok(response) => {
-            let mut entries: Vec<SessionRow> = response
-                .sessions
-                .into_iter()
-                .map(|(name, session)| {
-                    let domains = format_state_domains(&name, &session.domains);
-
-                    SessionRow {
-                        name,
-                        kind: session.kind,
-                        domains,
-                    }
-                })
-                .collect();
-
-            entries.sort_by(|a, b| a.kind.cmp(&b.kind).then(a.name.cmp(&b.name)));
-            entries
-        }
-        Err(_) => vec![],
-    }
 }
 
 async fn fetch_session_detail(session_name: &str) -> Option<SessionDetailResponse> {

--- a/linkup-cli/src/session.rs
+++ b/linkup-cli/src/session.rs
@@ -1,8 +1,9 @@
 use colored::Colorize;
 use linkup::{Domain, SessionKind};
+use linkup_clients::LocalServerClient;
 use serde::{Deserialize, Serialize};
 
-use crate::state::State;
+use crate::{services::local_server, state::State};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SessionRow {
@@ -18,6 +19,32 @@ impl SessionRow {
             kind,
             domains: format_state_domains(&state.linkup.session_name, &state.domains),
         }
+    }
+}
+
+pub async fn list_session_rows() -> Vec<SessionRow> {
+    let client = LocalServerClient::new(&local_server::url());
+
+    match client.list_sessions().await {
+        Ok(response) => {
+            let mut entries: Vec<SessionRow> = response
+                .sessions
+                .into_iter()
+                .map(|(name, session)| {
+                    let domains = format_state_domains(&name, &session.domains);
+
+                    SessionRow {
+                        name,
+                        kind: session.kind,
+                        domains,
+                    }
+                })
+                .collect();
+
+            entries.sort_by(|a, b| a.kind.cmp(&b.kind).then(a.name.cmp(&b.name)));
+            entries
+        }
+        Err(_) => vec![],
     }
 }
 


### PR DESCRIPTION
We now have a subcommand to create preview/isolated sessions and to delete the isolated ones.
But currently the way to see which sessions currently are available, you have to run `linkup status`, which does quite a bit more than necessary if you only wants to know the available ones.

This adds a subcommand `linkup sessions list` to print the table of available sessions.

Closes SHIP-2639