### PR TITLE
chore: fix typos in error messages, logs, and docs

### DIFF
--- a/docs/src/content/docs/explanation/how-it-works.md
+++ b/docs/src/content/docs/explanation/how-it-works.md
@@ -124,7 +124,7 @@ of the following questions:
 
 - Does the request come straight from the browser? Then it will have a `Referer`
   header that includes the linkup session name.
-- Have I instrumented the underlying service to propogate the opentelemetry
+- Have I instrumented the underlying service to propagate the opentelemetry
   tracing headers? If so, `tracestate` will include the linkup session name.
 
 ## Linkup Components

--- a/docs/src/content/docs/explanation/what-does-a-setup-look-like.md
+++ b/docs/src/content/docs/explanation/what-does-a-setup-look-like.md
@@ -22,7 +22,7 @@ Three things may need to be configured in your codebase for linkup to work well:
    "general" domain names of your linkup environment, like `api.example.com`,
    never `smart-snake.api.example.com` and your setup will work well.
 3. You may need to instrument your backend services to
-   [propogate opentelemetry state](https://opentelemetry.io/docs/concepts/context-propagation/).
+   [propagate opentelemetry state](https://opentelemetry.io/docs/concepts/context-propagation/).
 
 More information on configuration [here](/linkup/guides/configure).
 

--- a/linkup-cli/src/commands/health.rs
+++ b/linkup-cli/src/commands/health.rs
@@ -315,7 +315,7 @@ impl Display for Health {
             None => writeln!(f, "{}", "NOT SET".yellow())?,
         }
 
-        writeln!(f, "{}", "Background sevices:".bold().italic())?;
+        writeln!(f, "{}", "Background services:".bold().italic())?;
         write!(f, "  - Linkup Server  ")?;
         match &self.background_services.linkup_server {
             BackgroundServiceHealth::NotInstalled => writeln!(f, "{}", "NOT INSTALLED".yellow())?,

--- a/linkup-cli/src/main.rs
+++ b/linkup-cli/src/main.rs
@@ -231,7 +231,7 @@ enum Commands {
     #[clap(about = "Manage linkup infrastructure on Cloudflare")]
     Infra(commands::InfraArgs),
 
-    // Server command is hidden beacuse it is supposed to be managed only by the CLI itself.
+    // Server command is hidden because it is supposed to be managed only by the CLI itself.
     // It is called on `start` to start the local-server.
     #[clap(hide = true)]
     Server(commands::ServerArgs),

--- a/linkup-cli/src/services/cloudflared.rs
+++ b/linkup-cli/src/services/cloudflared.rs
@@ -179,7 +179,7 @@ async fn has_dns_propagated(tunnel_url: &Url) -> bool {
         let addresses = lookup.answers().iter().collect::<Vec<_>>();
 
         if !addresses.is_empty() {
-            log::debug!("DNS has propogated for {}.", domain);
+            log::debug!("DNS has propagated for {}.", domain);
 
             return true;
         }

--- a/linkup/src/lib.rs
+++ b/linkup/src/lib.rs
@@ -666,7 +666,7 @@ mod tests {
                 .unwrap();
 
         // Second request should have the same outcome
-        // The secret sauce should be in the extra headers that have been propogated
+        // The secret sauce should be in the extra headers that have been propagated
         assert_eq!(target.name, "backend");
         assert_eq!(target.url, "http://localhost:8001/user");
     }

--- a/local-server/src/handlers/proxy.rs
+++ b/local-server/src/handlers/proxy.rs
@@ -98,7 +98,7 @@ pub async fn handle_all(
                 upstream_request.headers_mut().insert(key, value.clone());
             }
 
-            // Overriding host header neccesary for tokio_tungstenite
+            // Overriding host header necessary for tokio_tungstenite
             upstream_request
                 .headers_mut()
                 .insert(http::header::HOST, HeaderValue::from_str(&host).unwrap());


### PR DESCRIPTION
Noticed the typo "Unalbe" when running `linkup start` before `LINKUP_CONFIG` was set. Ran [codespell](https://github.com/codespell-project/codespell) across the repo and found some others as well.