### PR TITLE
refactor: DNS catalog internal structure

### DIFF
--- a/local-server/src/dns.rs
+++ b/local-server/src/dns.rs
@@ -27,12 +27,38 @@ impl DnsCatalog {
         self.domains.read().await.iter().cloned().collect()
     }
 
-    pub(crate) async fn upsert_zone(&self, name: LowerName, handlers: Vec<Arc<dyn ZoneHandler>>) {
-        self.catalog.write().await.upsert(name, handlers);
+    pub async fn register_record(&self, domain: &str) {
+        let record_name = Name::from_str(&format!("{}.", domain))
+            .expect("dns record from domain should always succeed");
+
+        let authority: InMemoryZoneHandler<TokioRuntimeProvider> =
+            InMemoryZoneHandler::empty(record_name.clone(), ZoneType::Primary, AxfrPolicy::Deny);
+
+        let record = Record::from_rdata(
+            record_name.clone(),
+            3600,
+            RData::A(Ipv4Addr::new(127, 0, 0, 1).into()),
+        );
+
+        authority.upsert(record, 0).await;
+
+        self.catalog
+            .write()
+            .await
+            .upsert(record_name.into(), vec![Arc::new(authority)]);
+        self.domains.write().await.insert(domain.to_string());
     }
 
-    pub(crate) async fn remove_zone(&self, name: &LowerName) {
-        self.catalog.write().await.remove(name);
+    pub async fn deregister_record(&self, domain: &str) {
+        let record_name = Name::from_str(&format!("{}.", domain))
+            .expect("dns record from domain should always succeed");
+
+        self.catalog.write().await.remove(&record_name.into());
+        self.domains.write().await.remove(domain);
+    }
+
+    pub(crate) async fn upsert_zone(&self, name: LowerName, handlers: Vec<Arc<dyn ZoneHandler>>) {
+        self.catalog.write().await.upsert(name, handlers);
     }
 }
 
@@ -55,35 +81,4 @@ impl RequestHandler for DnsCatalog {
             .handle_request::<R, T>(request, response_handle)
             .await
     }
-}
-
-pub async fn register_dns_record(dns_catalog: &DnsCatalog, domain: &str) {
-    let record_name = Name::from_str(&format!("{}.", domain))
-        .expect("dns record from domain should always succeed");
-
-    let authority: InMemoryZoneHandler<TokioRuntimeProvider> =
-        InMemoryZoneHandler::empty(record_name.clone(), ZoneType::Primary, AxfrPolicy::Deny);
-
-    let record = Record::from_rdata(
-        record_name.clone(),
-        3600,
-        RData::A(Ipv4Addr::new(127, 0, 0, 1).into()),
-    );
-
-    authority.upsert(record, 0).await;
-
-    dns_catalog
-        .upsert_zone(record_name.into(), vec![Arc::new(authority)])
-        .await;
-
-    dns_catalog.domains.write().await.insert(domain.to_string());
-}
-
-pub async fn deregister_dns_record(dns_catalog: &DnsCatalog, domain: &str) {
-    let record_name = Name::from_str(&format!("{}.", domain))
-        .expect("dns record from domain should always succeed");
-
-    dns_catalog.remove_zone(&record_name.into()).await;
-
-    dns_catalog.domains.write().await.remove(domain);
 }

--- a/local-server/src/dns.rs
+++ b/local-server/src/dns.rs
@@ -30,6 +30,10 @@ impl DnsCatalog {
     pub(crate) async fn upsert_zone(&self, name: LowerName, handlers: Vec<Arc<dyn ZoneHandler>>) {
         self.catalog.write().await.upsert(name, handlers);
     }
+
+    pub(crate) async fn remove_zone(&self, name: &LowerName) {
+        self.catalog.write().await.remove(name);
+    }
 }
 
 impl Default for DnsCatalog {
@@ -73,4 +77,13 @@ pub async fn register_dns_record(dns_catalog: &DnsCatalog, domain: &str) {
         .await;
 
     dns_catalog.domains.write().await.insert(domain.to_string());
+}
+
+pub async fn deregister_dns_record(dns_catalog: &DnsCatalog, domain: &str) {
+    let record_name = Name::from_str(&format!("{}.", domain))
+        .expect("dns record from domain should always succeed");
+
+    dns_catalog.remove_zone(&record_name.into()).await;
+
+    dns_catalog.domains.write().await.remove(domain);
 }

--- a/local-server/src/dns.rs
+++ b/local-server/src/dns.rs
@@ -2,10 +2,14 @@ use std::{collections::BTreeSet, net::Ipv4Addr, str::FromStr, sync::Arc};
 
 use hickory_server::{
     net::runtime::{Time, TokioRuntimeProvider},
-    proto::rr::{LowerName, Name, RData, Record},
+    proto::rr::{Name, RData, Record},
+    resolver::config::{NameServerConfig, ResolverOpts},
     server::{Request, RequestHandler, ResponseHandler, ResponseInfo},
-    store::in_memory::InMemoryZoneHandler,
-    zone_handler::{AxfrPolicy, Catalog, ZoneHandler, ZoneType},
+    store::{
+        forwarder::{ForwardConfig, ForwardZoneHandler},
+        in_memory::InMemoryZoneHandler,
+    },
+    zone_handler::{AxfrPolicy, Catalog, ZoneType},
 };
 use tokio::sync::RwLock;
 
@@ -17,8 +21,29 @@ pub struct DnsCatalog {
 
 impl DnsCatalog {
     pub fn new() -> Self {
+        let mut catalog = Catalog::new();
+
+        let forward_config = ForwardConfig {
+            name_servers: vec![NameServerConfig::udp(
+                "1.1.1.1"
+                    .parse()
+                    .expect("1.1.1.1 should be a valid IP address"),
+            )],
+            options: Some(ResolverOpts::default()),
+        };
+
+        let forwarder = ForwardZoneHandler::builder_with_config(
+            forward_config,
+            TokioRuntimeProvider::default(),
+        )
+        .with_origin(Name::root())
+        .build()
+        .expect("ZoneHandler should be buildable with the current settings");
+
+        catalog.upsert(Name::root().into(), vec![Arc::new(forwarder)]);
+
         Self {
-            catalog: Arc::new(RwLock::new(Catalog::new())),
+            catalog: Arc::new(RwLock::new(catalog)),
             domains: Arc::new(RwLock::new(BTreeSet::new())),
         }
     }
@@ -55,10 +80,6 @@ impl DnsCatalog {
 
         self.catalog.write().await.remove(&record_name.into());
         self.domains.write().await.remove(domain);
-    }
-
-    pub(crate) async fn upsert_zone(&self, name: LowerName, handlers: Vec<Arc<dyn ZoneHandler>>) {
-        self.catalog.write().await.upsert(name, handlers);
     }
 }
 

--- a/local-server/src/handlers/sessions.rs
+++ b/local-server/src/handlers/sessions.rs
@@ -12,7 +12,7 @@ use linkup::{
 };
 use linkup_clients::WorkerClientError;
 
-use crate::{ServerState, dns, handlers::ApiError};
+use crate::{ServerState, handlers::ApiError};
 
 pub async fn list_sessions(State(server_state): State<ServerState>) -> impl IntoResponse {
     match server_state.session_allocator.list_sessions().await {
@@ -140,7 +140,7 @@ pub async fn upsert_tunneled(
             session_name = tunneled_session.session_name
         );
 
-        dns::register_dns_record(&server_state.dns_catalog, &full_domain).await;
+        server_state.dns_catalog.register_record(&full_domain).await;
     }
 
     (StatusCode::OK, Json(tunneled_session)).into_response()
@@ -214,7 +214,7 @@ pub async fn upsert_isolated(
     for domain in &domains {
         let full_domain = format!("{session_name}.{domain}");
 
-        dns::register_dns_record(&server_state.dns_catalog, &full_domain).await;
+        server_state.dns_catalog.register_record(&full_domain).await;
     }
 
     let session_response = SessionResponse {
@@ -265,7 +265,10 @@ pub async fn delete_session(
     for domain in &session.domains {
         let full_domain = format!("{session_name}.{domain}", domain = domain.domain);
 
-        dns::deregister_dns_record(&server_state.dns_catalog, &full_domain).await;
+        server_state
+            .dns_catalog
+            .deregister_record(&full_domain)
+            .await;
     }
 
     StatusCode::NO_CONTENT.into_response()

--- a/local-server/src/handlers/sessions.rs
+++ b/local-server/src/handlers/sessions.rs
@@ -228,7 +228,7 @@ pub async fn delete_session(
     State(server_state): State<ServerState>,
     Path(session_name): Path<String>,
 ) -> impl IntoResponse {
-    match server_state
+    let session = match server_state
         .session_allocator
         .find_session(&session_name)
         .await
@@ -247,8 +247,8 @@ pub async fn delete_session(
             )
             .into_response();
         }
-        Ok(Some(_)) => {}
-    }
+        Ok(Some(session)) => session,
+    };
 
     if let Err(error) = server_state
         .session_allocator
@@ -260,6 +260,12 @@ pub async fn delete_session(
             StatusCode::INTERNAL_SERVER_ERROR,
         )
         .into_response();
+    }
+
+    for domain in &session.domains {
+        let full_domain = format!("{session_name}.{domain}", domain = domain.domain);
+
+        dns::deregister_dns_record(&server_state.dns_catalog, &full_domain).await;
     }
 
     StatusCode::NO_CONTENT.into_response()

--- a/local-server/src/lib.rs
+++ b/local-server/src/lib.rs
@@ -9,13 +9,6 @@ use axum::{
     routing::{any, get, post},
 };
 use axum_server::tls_rustls::RustlsConfig;
-use hickory_server::net::runtime::TokioRuntimeProvider;
-use hickory_server::store::forwarder::ForwardZoneHandler;
-use hickory_server::{
-    proto::rr::Name,
-    resolver::config::{NameServerConfig, ResolverOpts},
-    store::forwarder::ForwardConfig,
-};
 use linkup::{MemoryStringStore, SessionAllocator};
 use linkup_clients::WorkerClient;
 use rustls::ServerConfig;
@@ -153,22 +146,6 @@ async fn start_server_http(server_state: ServerState) {
 }
 
 async fn start_dns_server(dns_catalog: DnsCatalog) {
-    let cf_name_server = NameServerConfig::udp("1.1.1.1".parse().unwrap());
-    let forward_config = ForwardConfig {
-        name_servers: vec![cf_name_server],
-        options: Some(ResolverOpts::default()),
-    };
-
-    let forwarder =
-        ForwardZoneHandler::builder_with_config(forward_config, TokioRuntimeProvider::default())
-            .with_origin(Name::root())
-            .build()
-            .unwrap();
-
-    dns_catalog
-        .upsert_zone(Name::root().into(), vec![Arc::new(forwarder)])
-        .await;
-
     let addr = SocketAddr::from(([0, 0, 0, 0], 8053));
     let sock = UdpSocket::bind(&addr).await.unwrap();
 


### PR DESCRIPTION
Move responsibility into the DnsCatalog to make interface simpler.
Mainly the initialization now takes care of setting up the forwarding to Cloudflare DNS server, and the registering adds to both the catalog and the internal domains list.